### PR TITLE
CA-679 Fix Sam provider passing in terra-env and output Sam service account emails

### DIFF
--- a/sam/outputs.tf
+++ b/sam/outputs.tf
@@ -4,10 +4,10 @@
 # output service accounts.
 #
 
-output "service_account_id" {
-  value = google_service_account.sam.account_id
+output "service_account_email" {
+  value = google_service_account.sam.email
 }
 
-output "admin_sdk_service_account_ids" {
-  value = google_service_account.sam_admin_sdk.*.account_id
+output "admin_sdk_service_account_emails" {
+  value = google_service_account.sam_admin_sdk.*.email
 }

--- a/terra-env/apps.tf
+++ b/terra-env/apps.tf
@@ -24,9 +24,12 @@ module "identity_concentrator" {
 
 module "sam" {
   # DO NOT MERGE fix to reference new release bump.
-  #source  = "github.com/broadinstitute/terraform-ap-modules.git//sam?ref=wc-CA-679"
-  source = "../sam"
-  google_project = var.google_project
+  #source = "github.com/broadinstitute/terraform-ap-modules.git//sam?ref=wc-CA-679"
+  source                         = "../sam"
+  google_project                 = var.google_project
   classic_storage_google_project = var.classic_storage_google_project
   num_admin_sdk_service_accounts = 3
+  providers = {
+    google.target = google.target
+  }
 }

--- a/terra-env/apps.tf
+++ b/terra-env/apps.tf
@@ -23,7 +23,9 @@ module "identity_concentrator" {
 }
 
 module "sam" {
-  source  = "github.com/broadinstitute/terraform-ap-modules.git//sam?ref=sam-0.0.1"
+  # DO NOT MERGE fix to reference new release bump.
+  #source  = "github.com/broadinstitute/terraform-ap-modules.git//sam?ref=wc-CA-679"
+  source = "../sam"
   google_project = var.google_project
   classic_storage_google_project = var.classic_storage_google_project
   num_admin_sdk_service_accounts = 3

--- a/terra-env/apps.tf
+++ b/terra-env/apps.tf
@@ -23,9 +23,7 @@ module "identity_concentrator" {
 }
 
 module "sam" {
-  # DO NOT MERGE fix to reference new release bump.
-  #source = "github.com/broadinstitute/terraform-ap-modules.git//sam?ref=wc-CA-679"
-  source                         = "../sam"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//sam?ref=sam-0.0.2"
   google_project                 = var.google_project
   classic_storage_google_project = var.classic_storage_google_project
   num_admin_sdk_service_accounts = 3

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -46,9 +46,9 @@ output "ic_db_creds" {
 #
 # Sam Outputs
 #
-output "sam_sa_id" {
-  value = module.sam.service_account_id
+output "sam_sa_email" {
+  value = module.sam.service_account_email
 }
-output "sam_admin_sdk_sa_ids" {
-  value = module.sam.admin_sdk_service_account_ids
+output "sam_admin_sdk_sa_emails" {
+  value = module.sam.admin_sdk_service_account_emails
 }


### PR DESCRIPTION
Sam service account emails seem to work better than `account_id`s when specifying the project as well as the SA id for google_service_account_key resources.