### PR TITLE
Add Monitoring to k8s cluster

### DIFF
--- a/terra-cluster/k8s-monitoring.tf
+++ b/terra-cluster/k8s-monitoring.tf
@@ -1,0 +1,4 @@
+module "cluster_monitoring" {
+  source  = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/k8s-cluster-monitoring?ref=k8s-cluster-monitoring-0.0.3-tf-0.12"
+  project = var.google_project
+}


### PR DESCRIPTION
Adds cluster wide monitoring via gcloud monitoring to cluster's created by this module.