### PR TITLE
CA-679 Add a node pool service account and a variable to give it GCR read access

### DIFF
--- a/terra-cluster/k8s.tf
+++ b/terra-cluster/k8s.tf
@@ -23,6 +23,7 @@ module "k8s-node-pool" {
   dependencies = [
     module.k8s-master
   ]
+  service_account = google_service_account.node_pool.email
 
   name        = var.node_pools[0].name
   master_name = module.k8s-master.name

--- a/terra-cluster/sa.tf
+++ b/terra-cluster/sa.tf
@@ -24,8 +24,8 @@ resource "google_service_account" "node_pool" {
 
 # Read and pull images from other_gcr_projects Google Container Registries.
 resource "google_project_iam_member" "node_pool" {
-  count = length(var.other_gcr_projects)
+  count   = length(var.other_gcr_projects)
   project = element(var.other_gcr_projects, count.index)
-  role = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.node_pool.email}"
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.node_pool.email}"
 }

--- a/terra-cluster/sa.tf
+++ b/terra-cluster/sa.tf
@@ -23,7 +23,7 @@ resource "google_service_account" "node_pool" {
 }
 
 # Read and pull images from other_gcr_projects Google Container Registries.
-resource "google_project_iam_member" "ci" {
+resource "google_project_iam_member" "node_pool" {
   count = length(var.other_gcr_projects)
   project = element(var.other_gcr_projects, count.index)
   role = "roles/storage.objectViewer"

--- a/terra-cluster/sa.tf
+++ b/terra-cluster/sa.tf
@@ -14,3 +14,11 @@ resource "google_project_iam_member" "ci" {
   role    = element(local.ci_sa_roles, count.index)
   member  = "serviceAccount:${google_service_account.ci.email}"
 }
+
+# Broad DSP Google Container Registry access.
+resource "google_project_iam_member" "ci" {
+  project = "broad-dsp-gcr-public"
+  # Read and pull images.
+  role = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.ci.email}"
+}

--- a/terra-cluster/sa.tf
+++ b/terra-cluster/sa.tf
@@ -15,10 +15,17 @@ resource "google_project_iam_member" "ci" {
   member  = "serviceAccount:${google_service_account.ci.email}"
 }
 
-# Broad DSP Google Container Registry access.
+# Service account for the k8s node pool.
+resource "google_service_account" "node_pool" {
+  project      = var.google_project
+  account_id   = "${local.owner}-node-pool"
+  display_name = "${local.owner}-node-pool"
+}
+
+# Read and pull images from other_gcr_projects Google Container Registries.
 resource "google_project_iam_member" "ci" {
-  project = "broad-dsp-gcr-public"
-  # Read and pull images.
+  count = length(var.other_gcr_projects)
+  project = element(var.other_gcr_projects, count.index)
   role = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.ci.email}"
+  member = "serviceAccount:${google_service_account.node_pool.email}"
 }

--- a/terra-cluster/variables.tf
+++ b/terra-cluster/variables.tf
@@ -74,6 +74,14 @@ locals {
   ]
 }
 
+# Which projects to give the node pool service account the 'roles/storage.objectViewer' role. The node service account
+# needs this read access to pull images from Google Container Registry for projects other than its own.
+variable "other_gcr_projects" {
+  type = list(string)
+  default = []
+  description = "List of projects with GCR that the k8s node pool needs access to for pulling images."
+}
+
 #
 # Monitoring Vars
 #

--- a/terra-cluster/variables.tf
+++ b/terra-cluster/variables.tf
@@ -77,8 +77,8 @@ locals {
 # Which projects to give the node pool service account the 'roles/storage.objectViewer' role. The node service account
 # needs this read access to pull images from Google Container Registry for projects other than its own.
 variable "other_gcr_projects" {
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
   description = "List of projects with GCR that the k8s node pool needs access to for pulling images."
 }
 


### PR DESCRIPTION
Sam's image is currently stored on broad-dsp-gcr-public. We need to give our node pool service account object reader privileges on that project in order for it to pull images from there.

This PR adds an explicitly created node pool service account instead of using the default service account. It also adds a variable to terra-cluster to allow specifying which projects to give storage object viewer read priveleges to.