### PR TITLE
Revert merges for pull request #8 & #9 from broadinstitute/k8s-monitoring-mf

### DIFF
--- a/terra-cluster/k8s-monitoring.tf
+++ b/terra-cluster/k8s-monitoring.tf
@@ -1,5 +1,4 @@
 module "cluster_monitoring" {
-  source                = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/k8s-cluster-monitoring?ref=k8s-cluster-monitoring-0.0.3-tf-0.12"
-  project               = var.google_project
-  notification_channels = var.notification_channels
+  source  = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/k8s-cluster-monitoring?ref=k8s-cluster-monitoring-0.0.3-tf-0.12"
+  project = var.google_project
 }

--- a/terra-cluster/k8s-monitoring.tf
+++ b/terra-cluster/k8s-monitoring.tf
@@ -1,4 +1,0 @@
-module "cluster_monitoring" {
-  source  = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/k8s-cluster-monitoring?ref=k8s-cluster-monitoring-0.0.3-tf-0.12"
-  project = var.google_project
-}

--- a/terra-cluster/variables.tf
+++ b/terra-cluster/variables.tf
@@ -73,13 +73,3 @@ locals {
     "roles/container.admin"
   ]
 }
-
-#
-# Monitoring Vars
-#
-
-variable "notification_channels" {
-  type        = list(string)
-  default     = []
-  description = "List of notification channel gcloud resources to send alerts to"
-}


### PR DESCRIPTION
There's an error with privileges making these changes hard to deploy. To unblock other work on this module, we're reverting the monitoring commits for now.