### PR TITLE
CA-679 Give the node pool SA the roles it needs to run a cluster.

### DIFF
--- a/terra-cluster/sa.tf
+++ b/terra-cluster/sa.tf
@@ -22,6 +22,24 @@ resource "google_service_account" "node_pool" {
   display_name = "${local.owner}-node-pool"
 }
 
+locals {
+  # Roles needed for the node pool service account to run a GKE cluster.
+  node_pool_gke_roles = [
+    "monitoring.viewer",
+    "monitoring.metricWriter",
+    "logging.logWriter",
+    # Google Container Registry read access.
+    "roles/storage.objectViewer"
+  ]
+}
+
+resource "google_project_iam_member" "node_pool_gke" {
+  count   = length(local.node_pool_gke_roles)
+  project = var.google_project
+  role    = element(local.node_pool_gke_roles, count.index)
+  member  = "serviceAccount:${google_service_account.node_pool.email}"
+}
+
 # Read and pull images from other_gcr_projects Google Container Registries.
 resource "google_project_iam_member" "node_pool" {
   count   = length(var.other_gcr_projects)

--- a/terra-cluster/sa.tf
+++ b/terra-cluster/sa.tf
@@ -33,7 +33,7 @@ locals {
   ]
 }
 
-resource "google_project_iam_member" "node_pool_gke" {
+resource "google_project_iam_member" "node_pool" {
   count   = length(local.node_pool_gke_roles)
   project = var.google_project
   role    = element(local.node_pool_gke_roles, count.index)
@@ -41,7 +41,7 @@ resource "google_project_iam_member" "node_pool_gke" {
 }
 
 # Read and pull images from other_gcr_projects Google Container Registries.
-resource "google_project_iam_member" "node_pool" {
+resource "google_project_iam_member" "node_pool_other_gcr" {
   count   = length(var.other_gcr_projects)
   project = element(var.other_gcr_projects, count.index)
   role    = "roles/storage.objectViewer"

--- a/terra-cluster/sa.tf
+++ b/terra-cluster/sa.tf
@@ -25,9 +25,9 @@ resource "google_service_account" "node_pool" {
 locals {
   # Roles needed for the node pool service account to run a GKE cluster.
   node_pool_gke_roles = [
-    "monitoring.viewer",
-    "monitoring.metricWriter",
-    "logging.logWriter",
+    "roles/monitoring.viewer",
+    "roles/monitoring.metricWriter",
+    "roles/logging.logWriter",
     # Google Container Registry read access.
     "roles/storage.objectViewer"
   ]


### PR DESCRIPTION
Per https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
this is a fix for 3b02fc79