### PR TITLE
Fix to provider mapping original monitoring pr

### DIFF
--- a/terra-cluster/k8s-monitoring.tf
+++ b/terra-cluster/k8s-monitoring.tf
@@ -1,0 +1,8 @@
+module "cluster_monitoring" {
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/k8s-cluster-monitoring?ref=k8s-cluster-monitoring-0.0.3-tf-0.12"
+  providers = {
+    google.target = google.target
+  }
+  project               = var.google_project
+  notification_channels = var.notification_channels
+}

--- a/terra-cluster/variables.tf
+++ b/terra-cluster/variables.tf
@@ -81,3 +81,13 @@ variable "other_gcr_projects" {
   default     = []
   description = "List of projects with GCR that the k8s node pool needs access to for pulling images."
 }
+
+
+#
+# Monitoring Variables
+#
+variable "notification_channels" {
+  type        = list(string)
+  default     = []
+  description = "A list of ids for channels to contact when an alert fires"
+}


### PR DESCRIPTION
Fixed version of original pr adding monitoring to terra-cluster module. Now with correct provider mapping. 