### PR TITLE
Added monitoring variables to implement work around for legacy

### DIFF
--- a/terra-cluster/k8s-monitoring.tf
+++ b/terra-cluster/k8s-monitoring.tf
@@ -3,7 +3,7 @@ module "cluster_monitoring" {
   providers = {
     google.target = google.target
   }
-  # Work around for legacy gcp projects being monitored from a common external stackdriver workspace
-  project               = "${var.use_legacy_stackdriver_workspace ? var.stackdriver_workspace_project : var.google_project}"
+  # Work around for legacy gcp projects being monitored from a common external stackdriver workspac
+  project               = var.use_legacy_stackdriver_workspace ? var.stackdriver_workspace_project : var.google_project
   notification_channels = var.notification_channels
 }

--- a/terra-cluster/k8s-monitoring.tf
+++ b/terra-cluster/k8s-monitoring.tf
@@ -3,6 +3,7 @@ module "cluster_monitoring" {
   providers = {
     google.target = google.target
   }
-  project               = var.google_project
+  # Work around for legacy gcp projects being monitored from a common external stackdriver workspace
+  project               = "${var.use_legacy_stackdriver_workspace ? var.stackdriver_workspace_project : var.google_project}"
   notification_channels = var.notification_channels
 }

--- a/terra-cluster/variables.tf
+++ b/terra-cluster/variables.tf
@@ -198,3 +198,15 @@ variable "notification_channels" {
   default     = []
   description = "A list of ids for channels to contact when an alert fires"
 }
+
+variable "stackdriver_workspace_project" {
+  type        = string
+  default     = "broad-dsp-stackdriver"
+  description = "The stackdriver workspace that monitors the legacy firecloud environments except broad-dsde-prod."
+}
+
+variable "use_legacy_stackdriver_workspace" {
+  type        = bool
+  default     = false
+  description = "Flag that should be enabled only if you are creating a cluster in one of the legacy firecloud gcp projects: broad-dsde-[dev/alpha/perf/staging]"
+}


### PR DESCRIPTION
firecloud gcp projects using a separately hosted stackdriver workspace.