### PR TITLE
DDO-285 Version bumps

### DIFF
--- a/terra-cluster/k8s-master.tf
+++ b/terra-cluster/k8s-master.tf
@@ -1,6 +1,6 @@
 module "k8s-master" {
   # terraform-shared repo
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-master?ref=k8s-master-0.2.1-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-master?ref=k8s-master-0.2.2-tf-0.12"
   dependencies = [
     module.enable-services,
     google_compute_network.k8s-cluster-network

--- a/terra-cluster/k8s-monitoring.tf
+++ b/terra-cluster/k8s-monitoring.tf
@@ -1,5 +1,5 @@
 module "cluster_monitoring" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/k8s-cluster-monitoring?ref=k8s-cluster-monitoring-0.0.3-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/stackdriver/k8s-cluster-monitoring?ref=k8s-cluster-monitoring-0.0.4-tf-0.12"
   providers = {
     google.target = google.target
   }

--- a/terra-cluster/k8s-pools.tf
+++ b/terra-cluster/k8s-pools.tf
@@ -5,7 +5,7 @@ locals {
 # Default node pool
 module "k8s-node-pool" {
   # terraform-shared repo
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.1.0-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.0-tf-0.12"
   dependencies = [
     module.k8s-master
   ]
@@ -25,7 +25,7 @@ module "k8s-node-pool" {
 
 # Highmem pool
 module "k8s-node-pool-highmem" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.1.0-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.0-tf-0.12"
   dependencies = [
     module.k8s-master
   ]


### PR DESCRIPTION
Bump the following modules:
* k8s-node-pool - explicity set upgrade_settings. This requires a google/google-beta provider > 3.14.0 
* k8s-master - pull in new version that doesn't anchor google provider to 3.2.0
* k8s-cluster-monitor - pull in new version that doesn't anchor google provider to 3.2.0