### PR TITLE
DDO-366 Subnet fix

### DIFF
--- a/terra-cluster/k8s-master.tf
+++ b/terra-cluster/k8s-master.tf
@@ -15,5 +15,10 @@ module "k8s-master" {
   subnetwork              = var.auto_create_subnets ? local.cluster_network : local.cluster_subnet
   private_ipv4_cidr_block = var.private_master_ipv4_cidr_block
 
+  ip_allocation_policy = {
+    cluster_secondary_range_name  = var.auto_create_subnets ? null : "pods"
+    services_secondary_range_name = var.auto_create_subnets ? null : "services"
+  }
+
   istio_enable = var.istio_enable
 }


### PR DESCRIPTION
Fix a bug where pod/service subnets were not being correctly passed to the k8s-master module.