### PR TITLE
[CA-870] Setup terraform for janitor service deployment.

### DIFF
--- a/crl-janitor/README.md
+++ b/crl-janitor/README.md
@@ -1,4 +1,4 @@
-# Workspace Manager
+# Cloud Resource Janitor Service
 
 This module creates the service account and CloudSQL databases necessary for 
 running the [CRL-Janitor](http://github.com/databiosphere/crl-janitor).

--- a/crl-janitor/README.md
+++ b/crl-janitor/README.md
@@ -1,0 +1,4 @@
+# Workspace Manager
+
+This module creates the service account and CloudSQL databases necessary for 
+running the [CRL-Janitor](http://github.com/databiosphere/crl-janitor).

--- a/crl-janitor/cloudsql.tf
+++ b/crl-janitor/cloudsql.tf
@@ -1,0 +1,25 @@
+module "cloudsql" {
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.1.0"
+
+  enable = var.enable
+
+  providers = {
+    google.target = google.target
+  }
+  project       = var.google_project
+  cloudsql_name = "${local.service}-db-${local.owner}"
+  cloudsql_instance_labels = {
+    "env" = local.owner
+    "app" = local.service
+  }
+  cloudsql_tier = var.db_tier
+
+  app_dbs = {
+    "${local.service}" = {
+      db       = local.db_name
+      username = local.db_user
+    }
+  }
+
+  dependencies = [ var.dependencies ]
+}

--- a/crl-janitor/dns.tf
+++ b/crl-janitor/dns.tf
@@ -1,0 +1,21 @@
+data "google_dns_managed_zone" "dns_zone" {
+  count = var.enable ? 1 : 0
+
+  provider = google.dns
+  name = var.dns_zone_name
+}
+
+locals {
+  fqdn = var.enable ? "${local.hostname}${local.subdomain_name}.${data.google_dns_managed_zone.dns_zone[0].dns_name}" : null
+}
+
+resource "google_dns_record_set" "ingress" {
+  count = var.enable ? 1 : 0
+  
+  provider = google.dns
+  managed_zone = data.google_dns_managed_zone.dns_zone[0].name
+  name         = local.fqdn
+  type         = "A"
+  ttl          = "300"
+  rrdatas    = [ google_compute_address.ingress_ip[0].address ]
+}

--- a/crl-janitor/ip.tf
+++ b/crl-janitor/ip.tf
@@ -1,0 +1,7 @@
+resource "google_compute_address" "ingress_ip" {
+  count = var.enable ? 1 : 0
+
+  provider = google.target
+
+  name     = "terra-${var.cluster}-${local.owner}-${local.service}-ip"
+}

--- a/crl-janitor/outputs.tf
+++ b/crl-janitor/outputs.tf
@@ -1,0 +1,35 @@
+#
+# Service Account Outputs
+#
+output "app_sa_id" {
+  value = var.enable ? google_service_account.app[0].account_id : null
+}
+
+#
+# IP/DNS Outputs
+#
+output "ingress_ip" {
+  value = var.enable ? google_compute_address.ingress_ip[0].address : null
+}
+output "fqdn" {
+  value = var.enable ? local.fqdn : null
+}
+
+#
+# CloudSQL PostgreSQL Outputs
+#
+output "cloudsql_public_ip" {
+  value = var.enable ? module.cloudsql.public_ip : null
+}
+output "cloudsql_instance_name" {
+  value = var.enable ? module.cloudsql.instance_name : null
+}
+output "cloudsql_root_user_password" {
+  value     = var.enable ? module.cloudsql.root_user_password : null
+  sensitive = true
+}
+output "cloudsql_app_db_creds" {
+  # Avoiding error on destroy with below condition
+  value     = var.enable ? (length(module.cloudsql.app_db_creds) == 0 ? {} : module.cloudsql.app_db_creds[local.service]) : null
+  sensitive = true
+}

--- a/crl-janitor/provider.tf
+++ b/crl-janitor/provider.tf
@@ -1,0 +1,11 @@
+provider "google" {
+  alias = "target"
+}
+
+provider "google" {
+  alias = "dns"
+}
+
+provider "google-beta" {
+  alias = "target"
+}

--- a/crl-janitor/sa.tf
+++ b/crl-janitor/sa.tf
@@ -1,0 +1,16 @@
+resource "google_service_account" "app" {
+  count = var.enable ? 1 : 0
+
+  provider = google.target
+  project      = var.google_project
+  account_id   = "${local.service}-${local.owner}"
+  display_name = "${local.service}-${local.owner}"
+}
+resource "google_project_iam_member" "app_roles" {
+  count = var.enable ? length(local.sa_roles) : 0
+
+  provider = google.target
+  project = var.google_project
+  role    = local.sa_roles[count.index]
+  member  = "serviceAccount:${google_service_account.app[0].email}"
+}

--- a/crl-janitor/variables.tf
+++ b/crl-janitor/variables.tf
@@ -30,7 +30,7 @@ variable "owner" {
   default     = ""
 }
 locals {
-  owner   = var.owner == "" ? terraform.crl-janitor : var.owner
+  owner   = var.owner == "" ? terraform.crl_janitor : var.owner
   service = "crl-janitor"
 }
 

--- a/crl-janitor/variables.tf
+++ b/crl-janitor/variables.tf
@@ -1,0 +1,98 @@
+#
+# General Vars
+#
+variable "dependencies" {
+  # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
+  type        = any
+  default     = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
+}
+variable "enable" {
+  type = bool
+  description = "Enable flag for this module. If set to false, no resources will be created."
+  default = true
+}
+variable "google_project" {
+  type        = string
+  description = "The google project"
+}
+variable "cluster" {
+  description = "Terra GKE cluster suffix, whatever is after terra-"
+}
+variable "cluster_short" {
+  type        = string
+  description = "Optional short cluster name"
+  default     = ""
+}
+variable "owner" {
+  type        = string
+  description = "Environment or developer"
+  default     = ""
+}
+locals {
+  owner   = var.owner == "" ? terraform.crl-janitor : var.owner
+  service = "crl-janitor"
+}
+
+
+#
+# Service Account Vars
+#
+locals {
+  sa_roles = [
+    "roles/cloudsql.client"
+  ]
+}
+
+
+#
+# DNS Vars
+#
+variable "dns_zone_name" {
+  type        = string
+  description = "DNS zone name"
+  default     = "dsp-envs"
+}
+variable "use_subdomain" {
+  type        = bool
+  description = "Whether to use a subdomain between the zone and hostname"
+  default     = true
+}
+variable "subdomain_name" {
+  type        = string
+  description = "Domain namespacing between zone and hostname"
+  default     = ""
+}
+variable "hostname" {
+  type        = string
+  description = "Service hostname"
+  default     = ""
+}
+locals {
+  hostname       = var.hostname == "" ? local.service : var.hostname
+  cluster_name   = var.cluster_short == "" ? var.cluster : var.cluster_short
+  subdomain_name = var.use_subdomain ? (var.subdomain_name == "" ? ".${local.owner}.${local.cluster_name}" : var.subdomain_name) : ""
+}
+
+
+#
+# Postgres CloudSQL DB Vars
+#
+variable "db_tier" {
+  default     = "db-g1-small"
+  description = "The default tier (DB instance size) for the CloudSQL instance"
+}
+variable "db_name" {
+  type        = string
+  description = "Postgres db name"
+  default     = ""
+}
+variable "db_user" {
+  type        = string
+  description = "Postgres username"
+  default     = ""
+}
+locals {
+  db_name = var.db_name == "" ? local.service : var.db_name
+  db_user = var.db_user == "" ? local.service : var.db_user
+}

--- a/crl-janitor/variables.tf
+++ b/crl-janitor/variables.tf
@@ -30,7 +30,7 @@ variable "owner" {
   default     = ""
 }
 locals {
-  owner   = var.owner == "" ? terraform.crl_janitor : var.owner
+  owner   = var.owner == "" ? terraform.workspace : var.owner
   service = "crl-janitor"
 }
 

--- a/crl-janitor/variables.tf
+++ b/crl-janitor/variables.tf
@@ -40,7 +40,14 @@ locals {
 #
 locals {
   sa_roles = [
-    "roles/cloudsql.client"
+    # Roles needed as a part of CRL Janitor functionality.
+    "roles/cloudsql.client",
+    "roles/cloudtrace.agent",
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    # Roles used in integration testing.
+    "roles/storage.admin",
+    "roles/bigquery.admin",
   ]
 }
 

--- a/crl-janitor/variables.tf
+++ b/crl-janitor/variables.tf
@@ -46,6 +46,7 @@ locals {
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
     # Roles used in integration testing.
+    "roles/resourcemanager.admin",
     "roles/storage.admin",
     "roles/bigquery.admin",
   ]

--- a/terra-env/apps.tf
+++ b/terra-env/apps.tf
@@ -76,7 +76,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=yyu-CA-870"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.0"
 
   enable = local.terra_apps["poc"]
 

--- a/terra-env/apps.tf
+++ b/terra-env/apps.tf
@@ -74,3 +74,23 @@ module "workspace_manager" {
     google-beta.target = google-beta.target
   }
 }
+
+module "crl_janitor" {
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.1"
+
+  enable = local.terra_apps["poc"]
+
+  google_project = var.google_project
+  cluster        = var.cluster
+  cluster_short  = var.cluster_short
+
+  dns_zone_name    = var.dns_zone_name
+  subdomain_name   = var.subdomain_name
+  use_subdomain    = var.use_subdomain
+
+  providers = {
+    google.target      = google.target
+    google.dns         = google.dns
+    google-beta.target = google-beta.target
+  }
+}

--- a/terra-env/apps.tf
+++ b/terra-env/apps.tf
@@ -76,7 +76,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.0"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=yyu-ca-870"
 
   enable = local.terra_apps["poc"]
 

--- a/terra-env/apps.tf
+++ b/terra-env/apps.tf
@@ -76,7 +76,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.1"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.0"
 
   enable = local.terra_apps["poc"]
 

--- a/terra-env/apps.tf
+++ b/terra-env/apps.tf
@@ -76,7 +76,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=yyu-ca-870"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=yyu-CA-870"
 
   enable = local.terra_apps["poc"]
 

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -109,3 +109,30 @@ output "workspace_ingress_ip" {
 output "workspace_fqdn" {
   value = module.workspace_manager.fqdn
 }
+
+#
+# CRL Janitor Service Outputs
+#
+output "crl-janitor_sa_id" {
+  value = module.crl_janitor.app_sa_id
+}
+output "crl-janitor_db_ip" {
+  value = module.crl_janitor.cloudsql_public_ip
+}
+output "crl-janitor_db_instance" {
+  value = module.crl_janitor.cloudsql_instance_name
+}
+output "crl-janitor_db_root_pass" {
+  value     = module.crl_janitor.cloudsql_root_user_password
+  sensitive = true
+}
+output "crl-janitor_db_creds" {
+  value     = module.crl_janitor.cloudsql_app_db_creds
+  sensitive = true
+}
+output "crl-janitor_ingress_ip" {
+  value = module.crl_janitor.ingress_ip
+}
+output "crl-janitor_fqdn" {
+  value = module.crl_janitor.fqdn
+}

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -113,26 +113,26 @@ output "workspace_fqdn" {
 #
 # CRL Janitor Service Outputs
 #
-output "crl-janitor_sa_id" {
+output "crl_janitor_sa_id" {
   value = module.crl_janitor.app_sa_id
 }
-output "crl-janitor_db_ip" {
+output "crl_janitor_db_ip" {
   value = module.crl_janitor.cloudsql_public_ip
 }
-output "crl-janitor_db_instance" {
+output "crl_janitor_db_instance" {
   value = module.crl_janitor.cloudsql_instance_name
 }
-output "crl-janitor_db_root_pass" {
+output "crl_janitor_db_root_pass" {
   value     = module.crl_janitor.cloudsql_root_user_password
   sensitive = true
 }
-output "crl-janitor_db_creds" {
+output "crl_janitor_db_creds" {
   value     = module.crl_janitor.cloudsql_app_db_creds
   sensitive = true
 }
-output "crl-janitor_ingress_ip" {
+output "crl_janitor_ingress_ip" {
   value = module.crl_janitor.ingress_ip
 }
-output "crl-janitor_fqdn" {
+output "crl_janitor_fqdn" {
   value = module.crl_janitor.fqdn
 }


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-870

Setup terraform for janitor service deployment.
Service description: 

- A service to cleanup resources created by CRL(Cloud Resource Library). 
- will need a cloudsql db
- some basic roles related with gcp resource management including resourcemanager, storage, bigquery