### PR TITLE
Ddo-337-prometheus-ingress Global Ips

### DIFF
--- a/prometheus/dns.tf
+++ b/prometheus/dns.tf
@@ -19,5 +19,5 @@ resource "google_dns_record_set" "ingress" {
   name         = local.fqdn
   type         = "A"
   ttl          = "300"
-  rrdatas      = [google_compute_address.ingress_ip[0].address]
+  rrdatas      = [google_compute_global_address.ingress_ip[0].address]
 }

--- a/prometheus/ip.tf
+++ b/prometheus/ip.tf
@@ -1,4 +1,4 @@
-resource "google_compute_address" "ingress_ip" {
+resource "google_compute_global_address" "ingress_ip" {
   count = var.enable ? 1 : 0
 
   provider = google.dns

--- a/prometheus/outputs.tf
+++ b/prometheus/outputs.tf
@@ -2,7 +2,7 @@
 # IP/DNS Outputs
 #
 output "ingress_ip" {
-  value = var.enable ? google_compute_address.ingress_ip[0].address : null
+  value = var.enable ? google_compute_global_address.ingress_ip[0].address : null
 }
 output "fqdn" {
   value = var.enable ? local.fqdn : null

--- a/terra-cluster/prometheus.tf
+++ b/terra-cluster/prometheus.tf
@@ -1,5 +1,5 @@
 module "prometheus" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//prometheus?ref=terra-cluster-0.0.13"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//prometheus?ref=DDO-337-prometheus-ingress"
 
   enable         = true
   environment    = local.owner

--- a/terra-cluster/prometheus.tf
+++ b/terra-cluster/prometheus.tf
@@ -1,5 +1,5 @@
 module "prometheus" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//prometheus?ref=DDO-337-prometheus-ingress"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//prometheus?ref=terra-cluster-0.0.14"
 
   enable         = true
   environment    = local.owner


### PR DESCRIPTION
This pr switches the static ips generated for prometheus ingresses from regional to global. This is a requirement of gke ingress