### PR TITLE
CA-941 support for Stairway to the CRL Janitor.

### DIFF
--- a/crl-janitor/cloudsql.tf
+++ b/crl-janitor/cloudsql.tf
@@ -19,6 +19,10 @@ module "cloudsql" {
       db       = local.db_name
       username = local.db_user
     }
+    "${local.service}-stairway" = {
+      db       = local.db_name
+      username = local.db_user
+    }
   }
 
   dependencies = [var.dependencies]

--- a/crl-janitor/outputs.tf
+++ b/crl-janitor/outputs.tf
@@ -40,3 +40,9 @@ output "cloudsql_app_db_creds" {
   description = "CRL Janitor database user credentials"
   sensitive   = true
 }
+output "cloudsql_app_stairway_db_creds" {
+  # Avoiding error on destroy with below condition
+  value       = var.enable ? (length(module.cloudsql.app_db_creds) == 0 ? {} : module.cloudsql.app_db_creds["${local.service}-stairway"]) : null
+  description = "CRL Janitor Stairway database user credentials"
+  sensitive   = true
+}

--- a/crl-janitor/variables.tf
+++ b/crl-janitor/variables.tf
@@ -41,6 +41,8 @@ locals {
 locals {
   sa_roles = [
     "roles/cloudsql.client",
+    # Stairway creates a pub/sub topic and subscription.
+    "roles/pubsub.admin",
   ]
 }
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -89,7 +89,8 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.3"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=wc-CA-941"
+  #source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.3"
 
   enable = local.terra_apps["poc"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -89,7 +89,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.2"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.3"
 
   enable = local.terra_apps["poc"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -89,8 +89,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=wc-CA-941"
-  #source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.3"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.3"
 
   enable = local.terra_apps["poc"]
 

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -156,6 +156,11 @@ output "crl_janitor_db_creds" {
   description = "CRL Janitor database user credentials"
   sensitive   = true
 }
+output "crl_janitor_stairway_db_creds" {
+  value       = module.crl_janitor.cloudsql_app_stairway_db_creds
+  description = "CRL Janitor Stairway database user credentials"
+  sensitive   = true
+}
 output "crl_janitor_ingress_ip" {
   value       = module.crl_janitor.ingress_ip
   description = "CRL Janitor ingress IP"


### PR DESCRIPTION
Add a CloudSQL database for Stairway and give the CRL service account pub/sub admin to create a queue for Stairway's internal use.