### PR TITLE
DDO-398 Fix to integ cluster ip being created in wrong project

### DIFF
--- a/prometheus/ip.tf
+++ b/prometheus/ip.tf
@@ -2,6 +2,7 @@ resource "google_compute_global_address" "ingress_ip" {
   count = var.enable ? 1 : 0
 
   provider = google.target
+  project  = var.google_project
 
   name = "terra-${local.owner}-${local.service}-ip"
 }

--- a/prometheus/ip.tf
+++ b/prometheus/ip.tf
@@ -1,7 +1,7 @@
 resource "google_compute_global_address" "ingress_ip" {
   count = var.enable ? 1 : 0
 
-  provider = google.dns
+  provider = google.target
   project  = local.project
 
   name = "terra-${local.owner}-${local.service}-ip"

--- a/prometheus/ip.tf
+++ b/prometheus/ip.tf
@@ -2,7 +2,6 @@ resource "google_compute_global_address" "ingress_ip" {
   count = var.enable ? 1 : 0
 
   provider = google.target
-  project  = local.project
 
   name = "terra-${local.owner}-${local.service}-ip"
 }

--- a/prometheus/outputs.tf
+++ b/prometheus/outputs.tf
@@ -2,12 +2,10 @@
 # IP/DNS Outputs
 #
 output "ingress_ip" {
-  # type        = string
   description = "Prometheus ingress IP"
   value       = var.enable ? google_compute_global_address.ingress_ip[0].address : null
 }
 output "fqdn" {
-  # type        = string
   description = "Prometheus FQDN"
   value       = var.enable ? local.fqdn : null
 }

--- a/prometheus/outputs.tf
+++ b/prometheus/outputs.tf
@@ -2,12 +2,12 @@
 # IP/DNS Outputs
 #
 output "ingress_ip" {
-  type        = string
+  # type        = string
   description = "Prometheus ingress IP"
   value       = var.enable ? google_compute_global_address.ingress_ip[0].address : null
 }
 output "fqdn" {
-  type        = string
+  # type        = string
   description = "Prometheus FQDN"
   value       = var.enable ? local.fqdn : null
 }

--- a/terra-cluster/prometheus.tf
+++ b/terra-cluster/prometheus.tf
@@ -1,5 +1,5 @@
 module "prometheus" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//prometheus?ref=DDO-398-fix-integ-prometheus-ip"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//prometheus?ref=terra-cluster-0.0.15"
 
   enable         = true
   environment    = local.owner

--- a/terra-cluster/prometheus.tf
+++ b/terra-cluster/prometheus.tf
@@ -1,5 +1,5 @@
 module "prometheus" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//prometheus?ref=terra-cluster-0.0.14"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//prometheus?ref=DDO-398-fix-integ-prometheus-ip"
 
   enable         = true
   environment    = local.owner


### PR DESCRIPTION
Initial version of the prometheus terraform module created the static ip for the prometheus server in dsp-devops instead of terra-kernel-k8s. This pr fixes this issue.