### PR TITLE
Update workspace manager to postgres 12

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -69,7 +69,7 @@ module "sam_persistence" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.1.1"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=iz-update-wsm-pg-version"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -8,6 +8,7 @@ module "cloudsql" {
   }
   project       = var.google_project
   cloudsql_name = "${local.service}-db-${local.owner}"
+  cloudsql_version = "POSTGRES_12"
   cloudsql_instance_labels = {
     "env" = local.owner
     "app" = local.service


### PR DESCRIPTION
Hello! We'd like to upgrade wsm to to less-ancient postgres. What else needs to happen to do this?

https://github.com/broadinstitute/terraform-ap-deployments/pull/75