### PR TITLE
Add WSM Postgres DB version

### DIFF
--- a/crl-janitor/README.md
+++ b/crl-janitor/README.md
@@ -1,7 +1,7 @@
 # Cloud Resource Janitor Service module
 
 This module creates the service account and CloudSQL databases necessary for  
-running the [CRL-Janitor](http://github.com/databiosphere/crl-janitor) and a service account to access this service. 
+running the [CRL-Janitor](http://github.com/databiosphere/crl-janitor).
 
 For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)  
 and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
@@ -45,6 +45,7 @@ No requirements.
 | Name | Description |
 |------|-------------|
 | app\_sa\_id | CRL Janitor Google service accout ID |
+| client\_sa\_id | User Google service account email |
 | ingress\_ip | CRL Janitor ingress IP |
 | fqdn | CRL Janitor fully qualified domain name |
 | cloudsql\_public\_ip | CRL Janitor CloudSQL instance IP |

--- a/single-cell-portal/README.md
+++ b/single-cell-portal/README.md
@@ -19,9 +19,9 @@ No requirements.
 |------|---------|
 | google.dns | n/a |
 | random | n/a |
-| google.target | n/a |
-| google-beta.target | n/a |
 | http | n/a |
+| google-beta.target | n/a |
+| google.target | n/a |
 
 ## Inputs
 

--- a/single-cell-portal/README.md
+++ b/single-cell-portal/README.md
@@ -18,8 +18,8 @@ No requirements.
 | Name | Version |
 |------|---------|
 | google.dns | n/a |
-| random | n/a |
 | http | n/a |
+| random | n/a |
 | google-beta.target | n/a |
 | google.target | n/a |
 

--- a/single-cell-portal/README.md
+++ b/single-cell-portal/README.md
@@ -18,9 +18,9 @@ No requirements.
 | Name | Version |
 |------|---------|
 | google.dns | n/a |
-| http | n/a |
 | random | n/a |
 | google.target | n/a |
+| http | n/a |
 | google-beta.target | n/a |
 
 ## Inputs

--- a/single-cell-portal/README.md
+++ b/single-cell-portal/README.md
@@ -20,8 +20,8 @@ No requirements.
 | google.dns | n/a |
 | http | n/a |
 | random | n/a |
-| google-beta.target | n/a |
 | google.target | n/a |
+| google-beta.target | n/a |
 
 ## Inputs
 

--- a/terra-env/README.md
+++ b/terra-env/README.md
@@ -31,7 +31,7 @@ No provider.
 | dns\_zone\_name | DNS zone name | `string` | `"dsp-envs"` | no |
 | subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
-| wsm\_db\_version | The version for the WSM CloudSQL instance | `string` | `""` | no |
+| wsm\_db\_version | The version for the WSM CloudSQL instance | `string` | `"POSTGRES_9_6"` | no |
 
 ## Outputs
 
@@ -63,7 +63,8 @@ No provider.
 | workspace\_stairway\_db\_creds | Stairway database user credentials |
 | workspace\_ingress\_ip | Workspace Manager ingress IP |
 | workspace\_fqdn | Workspace Manager fully qualified domain name |
-| crl\_janitor\_sa\_id | CRL Janitor Google service accout ID |
+| crl\_janitor\_sa\_id | CRL Janitor Google service account ID |
+| crl\_janitor\_client\_sa\_id | CRL Janitor Google service account ID |
 | crl\_janitor\_db\_ip | CRL Janitor CloudSQL instance IP |
 | crl\_janitor\_db\_instance | CRL Janitor CloudSQL instance name |
 | crl\_janitor\_db\_root\_pass | CRL Janitor database root password |

--- a/terra-env/README.md
+++ b/terra-env/README.md
@@ -32,6 +32,7 @@ No provider.
 | subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
 | wsm\_db\_version | The version for the WSM CloudSQL instance | `string` | `"POSTGRES_9_6"` | no |
+| wsm\_db\_keepers | Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility | `bool` | `false` | no |
 
 ## Outputs
 

--- a/terra-env/README.md
+++ b/terra-env/README.md
@@ -31,7 +31,7 @@ No provider.
 | dns\_zone\_name | DNS zone name | `string` | `"dsp-envs"` | no |
 | subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
-| wsm\_db\_version | The version for the WSM CloudSQL instance. Default if left empty. | `string` | `""` | no |
+| wsm\_db\_version | The version for the WSM CloudSQL instance | `string` | `""` | no |
 
 ## Outputs
 

--- a/terra-env/README.md
+++ b/terra-env/README.md
@@ -31,6 +31,7 @@ No provider.
 | dns\_zone\_name | DNS zone name | `string` | `"dsp-envs"` | no |
 | subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
+| wsm\_db\_version | The version for the WSM CloudSQL instance. Default if left empty. | `string` | `""` | no |
 
 ## Outputs
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -69,7 +69,7 @@ module "sam_persistence" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=iz-update-wsm-pg-version"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=gm-wsm-pg-update"
 
   enable = local.terra_apps["workspace_manager"]
 
@@ -80,6 +80,8 @@ module "workspace_manager" {
   dns_zone_name  = var.dns_zone_name
   subdomain_name = var.subdomain_name
   use_subdomain  = var.use_subdomain
+
+  db_version = var.wsm_db_version == "" ? null : var.wsm_db_version
 
   providers = {
     google.target      = google.target

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -69,7 +69,7 @@ module "sam_persistence" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=gm-wsm-pg-update"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.2.0"
 
   enable = local.terra_apps["workspace_manager"]
 
@@ -81,7 +81,7 @@ module "workspace_manager" {
   subdomain_name = var.subdomain_name
   use_subdomain  = var.use_subdomain
 
-  db_version = var.wsm_db_version == "" ? null : var.wsm_db_version
+  db_version = var.wsm_db_version
 
   providers = {
     google.target      = google.target

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -82,6 +82,7 @@ module "workspace_manager" {
   use_subdomain  = var.use_subdomain
 
   db_version = var.wsm_db_version
+  db_keepers = var.wsm_db_keepers
 
   providers = {
     google.target      = google.target

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -69,7 +69,7 @@ module "sam_persistence" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.1.1"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=iz-update-wsm-pg-version"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -91,3 +91,8 @@ variable "wsm_db_version" {
   default     = "POSTGRES_9_6"
   description = "The version for the WSM CloudSQL instance"
 }
+variable "wsm_db_keepers" {
+  type        = bool
+  default     = false
+  description = "Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility"
+}

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -89,5 +89,5 @@ variable "use_subdomain" {
 variable "wsm_db_version" {
   type        = string
   default     = ""
-  description = "The version for the WSM CloudSQL instance. Default if left empty."
+  description = "The version for the WSM CloudSQL instance"
 }

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -88,6 +88,6 @@ variable "use_subdomain" {
 #
 variable "wsm_db_version" {
   type        = string
-  default     = ""
+  default     = "POSTGRES_9_6"
   description = "The version for the WSM CloudSQL instance"
 }

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -82,3 +82,12 @@ variable "use_subdomain" {
   description = "Whether to use a subdomain between the zone and hostname"
   default     = true
 }
+
+#
+# Workspace Manager Vars
+#
+variable "wsm_db_version" {
+  type        = string
+  default     = ""
+  description = "The version for the WSM CloudSQL instance. Default if left empty."
+}

--- a/terra-workspace-manager/README.md
+++ b/terra-workspace-manager/README.md
@@ -36,7 +36,7 @@ No requirements.
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
 | subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
 | hostname | Service hostname | `string` | `""` | no |
-| db\_version | The version for the CloudSQL instance | `string` | `""` | no |
+| db\_version | The version for the CloudSQL instance | `string` | `"POSTGRES_9_6"` | no |
 | db\_tier | The default tier (DB instance size) for the CloudSQL instance | `string` | `"db-g1-small"` | no |
 | db\_name | Postgres db name | `string` | `""` | no |
 | db\_user | Postgres username | `string` | `""` | no |

--- a/terra-workspace-manager/README.md
+++ b/terra-workspace-manager/README.md
@@ -36,6 +36,7 @@ No requirements.
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
 | subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
 | hostname | Service hostname | `string` | `""` | no |
+| db\_version | The version for the CloudSQL instance. Default if left empty. | `string` | `""` | no |
 | db\_tier | The default tier (DB instance size) for the CloudSQL instance | `string` | `"db-g1-small"` | no |
 | db\_name | Postgres db name | `string` | `""` | no |
 | db\_user | Postgres username | `string` | `""` | no |

--- a/terra-workspace-manager/README.md
+++ b/terra-workspace-manager/README.md
@@ -37,6 +37,7 @@ No requirements.
 | subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
 | hostname | Service hostname | `string` | `""` | no |
 | db\_version | The version for the CloudSQL instance | `string` | `"POSTGRES_9_6"` | no |
+| db\_keepers | Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility | `bool` | `false` | no |
 | db\_tier | The default tier (DB instance size) for the CloudSQL instance | `string` | `"db-g1-small"` | no |
 | db\_name | Postgres db name | `string` | `""` | no |
 | db\_user | Postgres username | `string` | `""` | no |

--- a/terra-workspace-manager/README.md
+++ b/terra-workspace-manager/README.md
@@ -36,7 +36,7 @@ No requirements.
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
 | subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
 | hostname | Service hostname | `string` | `""` | no |
-| db\_version | The version for the CloudSQL instance. Default if left empty. | `string` | `""` | no |
+| db\_version | The version for the CloudSQL instance | `string` | `""` | no |
 | db\_tier | The default tier (DB instance size) for the CloudSQL instance | `string` | `"db-g1-small"` | no |
 | db\_name | Postgres db name | `string` | `""` | no |
 | db\_user | Postgres username | `string` | `""` | no |

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -9,7 +9,7 @@ module "cloudsql" {
   project       = var.google_project
   cloudsql_name = "${local.service}-db-${local.owner}"
   cloudsql_version = var.db_version
-  cloudsql_keepers = true
+  cloudsql_keepers = var.db_keepers
   cloudsql_instance_labels = {
     "env" = local.owner
     "app" = local.service

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -8,6 +8,7 @@ module "cloudsql" {
   }
   project       = var.google_project
   cloudsql_name = "${local.service}-db-${local.owner}"
+  cloudsql_version = "POSTGRES_12"
   cloudsql_instance_labels = {
     "env" = local.owner
     "app" = local.service

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -1,5 +1,5 @@
 module "cloudsql" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.1.0"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=gm-postgres-update"
 
   enable = var.enable
 
@@ -8,7 +8,7 @@ module "cloudsql" {
   }
   project       = var.google_project
   cloudsql_name = "${local.service}-db-${local.owner}"
-  cloudsql_version = "POSTGRES_12"
+  cloudsql_version = var.db_version == "" ? null : var.db_version
   cloudsql_instance_labels = {
     "env" = local.owner
     "app" = local.service

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -1,5 +1,5 @@
 module "cloudsql" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=gm-postgres-update"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.2.1"
 
   enable = var.enable
 
@@ -8,7 +8,8 @@ module "cloudsql" {
   }
   project       = var.google_project
   cloudsql_name = "${local.service}-db-${local.owner}"
-  cloudsql_version = var.db_version == "" ? null : var.db_version
+  cloudsql_version = var.db_version
+  cloudsql_keepers = true
   cloudsql_instance_labels = {
     "env" = local.owner
     "app" = local.service

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -82,7 +82,7 @@ locals {
 variable "db_version" {
   type        = string
   default     = ""
-  description = "The version for the CloudSQL instance. Default if left empty."
+  description = "The version for the CloudSQL instance"
 }
 variable "db_tier" {
   type        = string

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -79,7 +79,13 @@ locals {
 #
 # Postgres CloudSQL DB Vars
 #
+variable "db_version" {
+  type        = string
+  default     = ""
+  description = "The version for the CloudSQL instance. Default if left empty."
+}
 variable "db_tier" {
+  type        = string
   default     = "db-g1-small"
   description = "The default tier (DB instance size) for the CloudSQL instance"
 }

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -81,7 +81,7 @@ locals {
 #
 variable "db_version" {
   type        = string
-  default     = ""
+  default     = "POSTGRES_9_6"
   description = "The version for the CloudSQL instance"
 }
 variable "db_tier" {

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -84,6 +84,11 @@ variable "db_version" {
   default     = "POSTGRES_9_6"
   description = "The version for the CloudSQL instance"
 }
+variable "db_keepers" {
+  type        = bool
+  default     = false
+  description = "Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility"
+}
 variable "db_tier" {
   type        = string
   default     = "db-g1-small"


### PR DESCRIPTION
Enable changing the DB version in a way that:
- Allows for changing it one env at a time via tfvars
- Prevents TF from trying to re-create it with the same ID by making the version a keeper of the ID

Related PRs:
- https://github.com/broadinstitute/terraform-ap-deployments/pull/76
- https://github.com/broadinstitute/terraform-shared/pull/117/files