### PR TITLE
DDO-473 Configure envs-terra.bio DNS records for Data Repo

### DIFF
--- a/datarepo/README.md
+++ b/datarepo/README.md
@@ -1,0 +1,35 @@
+# Terra Data Repo module
+
+This module creates DNS records for Data Repo in Terra environments.
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google.dns | n/a |
+| google.target | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| dependencies | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
+| dns\_zone\_name | DNS zone name | `string` | `""` | no |
+| dns\_zone\_project | DNS zone project | `string` | `""` | no |
+| enable | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
+| hostname | DNS hostname | `string` | `"data"` | no |
+| owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
+| static\_ip\_name | Name of Data Repo's static IP | `string` | n/a | yes |
+| static\_ip\_project | The google project where Data Repo's static IP lives | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| fqdn | Datarepo fully qualified domain name |
+| ingress\_ip | Datarepo ingress IP |
+

--- a/datarepo/dns.tf
+++ b/datarepo/dns.tf
@@ -1,0 +1,32 @@
+data "google_dns_managed_zone" "dns_zone" {
+  count = var.enable ? 1 : 0
+
+  provider = google.dns
+  name     = var.dns_zone_name
+  project  = var.dns_zone_project
+}
+
+data "google_compute_global_address" "ingress_ip" {
+  count = var.enable ? 1 : 0
+
+  provider = google.target
+  name     = var.static_ip_name
+  project  = var.static_ip_project
+}
+
+locals {
+  fqdn = var.enable ? "${var.hostname}.${local.owner}.${data.google_dns_managed_zone.dns_zone[0].dns_name}" : null
+}
+
+# data.alpha.envs-terra.bio
+resource "google_dns_record_set" "ingress" {
+  count = var.enable ? 1 : 0
+
+  provider     = google.dns
+  managed_zone = data.google_dns_managed_zone.dns_zone[0].name
+  name         = local.fqdn
+  type         = "A"
+  ttl          = "300"
+  rrdatas      = [data.google_compute_global_address.ingress_ip[0].address]
+  project      = var.dns_zone_project
+}

--- a/datarepo/main.tf
+++ b/datarepo/main.tf
@@ -1,0 +1,6 @@
+/**
+ * # Terra Data Repo module
+ * 
+ * This module creates DNS records for Data Repo in Terra environments.
+ *
+ */

--- a/datarepo/outputs.tf
+++ b/datarepo/outputs.tf
@@ -1,0 +1,11 @@
+#
+# IP/DNS Outputs
+#
+output "ingress_ip" {
+  value       = var.enable ? data.google_compute_global_address.ingress_ip[0].address : null
+  description = "Datarepo ingress IP"
+}
+output "fqdn" {
+  value       = var.enable ? local.fqdn : null
+  description = "Datarepo fully qualified domain name"
+}

--- a/datarepo/provider.tf
+++ b/datarepo/provider.tf
@@ -1,0 +1,11 @@
+provider "google" {
+  alias = "target"
+}
+
+provider "google" {
+  alias = "dns"
+}
+
+provider "google-beta" {
+  alias = "target"
+}

--- a/datarepo/variables.tf
+++ b/datarepo/variables.tf
@@ -1,0 +1,47 @@
+variable "dependencies" {
+  # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
+  type        = any
+  default     = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
+}
+variable "enable" {
+  type        = bool
+  description = "Enable flag for this module. If set to false, no resources will be created."
+  default     = true
+}
+variable "owner" {
+  type        = string
+  description = "Environment or developer. Defaults to TF workspace name if left blank."
+  default     = ""
+}
+locals {
+  owner = var.owner == "" ? terraform.workspace : var.owner
+}
+
+#
+# DNS Vars
+#
+variable "hostname" {
+  type        = string
+  description = "DNS hostname"
+  default     = "data"
+}
+variable "dns_zone_name" {
+  type        = string
+  description = "DNS zone name"
+  default     = ""
+}
+variable "dns_zone_project" {
+  type        = string
+  description = "DNS zone project"
+  default     = ""
+}
+
+variable "static_ip_name" {
+  type        = string
+  description = "Name of Data Repo's static IP"
+}
+variable "static_ip_project" {
+  type        = string
+  description = "The google project where Data Repo's static IP lives"
+}

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -3,7 +3,7 @@
  *
  * This Terraform module manages resources for a single Terra environment.
  * Each Terra application's resources are defined in its own module that this module references.
- * 
+ *
  * For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
  * and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
  *
@@ -103,6 +103,26 @@ module "crl_janitor" {
   dns_zone_name  = var.dns_zone_name
   subdomain_name = var.subdomain_name
   use_subdomain  = var.use_subdomain
+
+  providers = {
+    google.target      = google.target
+    google.dns         = google.dns
+    google-beta.target = google-beta.target
+  }
+}
+
+module "datarepo" {
+  source = "github.com/broadinstitute/terraform-ap-modules.git//datarepo?ref=datarepo-0.1.0"
+
+  enable = local.terra_apps["datarepo"]
+
+  # Create Datarepo DNS records
+  # data.<env>.envs-terra.bio
+  dns_zone_name    = "envs-terra"
+  dns_zone_project = "dsp-devops"
+
+  static_ip_name    = var.datarepo_static_ip_name
+  static_ip_project = var.datarepo_static_ip_project
 
   providers = {
     google.target      = google.target

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -59,6 +59,7 @@ locals {
     sam_persistence       = false,
     workspace_manager     = false,
     crl_janitor           = false,
+    datarepo              = false,
     },
     var.terra_apps
   )
@@ -95,4 +96,18 @@ variable "wsm_db_keepers" {
   type        = bool
   default     = false
   description = "Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility"
+}
+
+#
+# Datarepo Vars
+#
+variable "datarepo_static_ip_name" {
+  type        = string
+  default     = ""
+  description = "Name of Data Repo's static IP"
+}
+variable "datarepo_static_ip_project" {
+  type        = string
+  default     = ""
+  description = "Project where of Data Repo's static IP lives"
 }


### PR DESCRIPTION
Create a new service module for `datarepo` that only sets up DNS records.
Configure the module to create `data.<env>.envs-terra.bio` DNS records for Data Repo in alpha and staging.