### PR TITLE
PF-3 Janitor add cloudsql proxy SA and modify roles

### DIFF
--- a/crl-janitor/README.md
+++ b/crl-janitor/README.md
@@ -19,6 +19,7 @@ No requirements.
 |------|---------|
 | google.dns | n/a |
 | google.target | n/a |
+| google | n/a |
 
 ## Inputs
 
@@ -27,6 +28,7 @@ No requirements.
 | dependencies | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
 | enable | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
 | google\_project | The google project in which to create resources | `string` | n/a | yes |
+| google\_folder\_id | The folder in which Janitor has permission to delete resources. | `string` | `""` | no |
 | cluster | Terra GKE cluster suffix, whatever is after terra- | `string` | n/a | yes |
 | cluster\_short | Optional short cluster name | `string` | `""` | no |
 | owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
@@ -45,6 +47,7 @@ No requirements.
 | Name | Description |
 |------|-------------|
 | app\_sa\_id | CRL Janitor Google service accout ID |
+| sqlproxy\_sa\_id | CRL Janitor Cloud SQL Proxy Google service account ID |
 | client\_sa\_id | User Google service account email |
 | ingress\_ip | CRL Janitor ingress IP |
 | fqdn | CRL Janitor fully qualified domain name |
@@ -53,5 +56,6 @@ No requirements.
 | cloudsql\_root\_user\_password | CRL Janitor database root password |
 | cloudsql\_app\_db\_creds | CRL Janitor database user credentials |
 | cloudsql\_app\_stairway\_db\_creds | CRL Janitor Stairway database user credentials |
-| pubsub\_topic\ | CRL Janitor Pub/sub topic |
-| pubsub\_subscription\ | CRL Janitor Pub/sub subscription name |
+| pubsub\_topic | CRL Janitor Pub/sub topic |
+| pubsub\_subscription | CRL Janitor Pub/sub subscription name |
+

--- a/crl-janitor/outputs.tf
+++ b/crl-janitor/outputs.tf
@@ -5,6 +5,10 @@ output "app_sa_id" {
   value       = var.enable ? google_service_account.app[0].account_id : null
   description = "CRL Janitor Google service accout ID"
 }
+output "sqlproxy_sa_id" {
+  value       = var.enable ? google_service_account.sqlproxy[0].account_id : null
+  description = "CRL Janitor Cloud SQL Proxy Google service account ID"
+}
 output "client_sa_id" {
   value       = var.enable ? google_service_account.client[0].account_id : null
   description = "User Google service account email"

--- a/crl-janitor/sa.tf
+++ b/crl-janitor/sa.tf
@@ -1,3 +1,35 @@
+# The service account for the cloudsql proxy.
+resource "google_service_account" "sqlproxy" {
+  count = var.enable ? 1 : 0
+
+  provider     = google.target
+  project      = var.google_project
+  account_id   = "${local.service}-${local.owner}-sqlproxy"
+  display_name = "${local.service}-${local.owner}-sqlproxy"
+}
+resource "google_project_iam_member" "sqlproxy_role" {
+  count = var.enable ? 1 : 0
+
+  provider = google.target
+  project  = var.google_project
+  role     = "roles/cloudsql.client"
+  member   = "serviceAccount:${google_service_account.sqlproxy[0].email}"
+}
+
+locals {
+  app_sa_roles = [
+    # TODO: remove cloudsql.client deprecated by separate service account once we have migrated
+    # existing deployments.
+    "roles/cloudsql.client",
+    # Stairway publishes and subscribes to pubsub.
+    "roles/pubsub.publisher",
+    "roles/pubsub.subscriber",
+    # Allow the creation and exporting of monitoring metrics.
+    "roles/monitoring.editor"
+  ]
+}
+
+# The main service account for the Janitor service app.
 resource "google_service_account" "app" {
   count = var.enable ? 1 : 0
 
@@ -8,11 +40,11 @@ resource "google_service_account" "app" {
 }
 
 resource "google_project_iam_member" "app_roles" {
-  count = var.enable ? length(local.sa_roles) : 0
+  count = var.enable ? length(local.app_sa_roles) : 0
 
   provider = google.target
   project  = var.google_project
-  role     = local.sa_roles[count.index]
+  role     = local.app_sa_roles[count.index]
   member   = "serviceAccount:${google_service_account.app[0].email}"
 }
 

--- a/crl-janitor/variables.tf
+++ b/crl-janitor/variables.tf
@@ -41,17 +41,6 @@ locals {
 }
 
 #
-# Service Account Vars
-#
-locals {
-  sa_roles = [
-    "roles/cloudsql.client",
-    # Stairway creates a pub/sub topic and subscription.
-    "roles/pubsub.admin",
-  ]
-}
-
-#
 # DNS Vars
 #
 variable "dns_zone_name" {

--- a/terra-env/README.md
+++ b/terra-env/README.md
@@ -33,7 +33,9 @@ No provider.
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
 | wsm\_db\_version | The version for the WSM CloudSQL instance | `string` | `"POSTGRES_9_6"` | no |
 | wsm\_db\_keepers | Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility | `bool` | `false` | no |
-| janitor\_google\_folder\_id | The folder in which Janitor has permission to cleanup resources. | `string` | n/a | no |
+| datarepo\_static\_ip\_name | Name of Data Repo's static IP | `string` | `""` | no |
+| datarepo\_static\_ip\_project | Project where of Data Repo's static IP lives | `string` | `""` | no |
+| janitor\_google\_folder\_id | The folder ID in which Janitor has permission to cleanup resources. | `string` | `""` | no |
 
 ## Outputs
 
@@ -57,7 +59,8 @@ No provider.
 | sam\_db\_instance | SAM CloudSQL instance name |
 | sam\_db\_root\_password | SAM database root password |
 | sam\_db\_creds | SAM database user credentials |
-| workspace\_sa\_id | Workspace Manager Google service accout ID |
+| workspace\_sqlproxy\_sa\_id | Workspace Manager Cloud SQL Proxy Google service account ID |
+| workspace\_cloud\_trace\_sa\_id | Workspace Manager Cloud trace Google service account ID |
 | workspace\_db\_ip | Workspace Manager CloudSQL instance IP |
 | workspace\_db\_instance | Workspace Manager CloudSQL instance name |
 | workspace\_db\_root\_pass | Workspace Manager database root password |
@@ -66,6 +69,7 @@ No provider.
 | workspace\_ingress\_ip | Workspace Manager ingress IP |
 | workspace\_fqdn | Workspace Manager fully qualified domain name |
 | crl\_janitor\_sa\_id | CRL Janitor Google service account ID |
+| crl\_janitor\_sqlproxy\_sa\_id | CRL Janitor Cloud SQL Proxy Google service account ID |
 | crl\_janitor\_client\_sa\_id | CRL Janitor Google service account ID |
 | crl\_janitor\_db\_ip | CRL Janitor CloudSQL instance IP |
 | crl\_janitor\_db\_instance | CRL Janitor CloudSQL instance name |
@@ -74,4 +78,6 @@ No provider.
 | crl\_janitor\_stairway\_db\_creds | CRL Janitor Stairway database user credentials |
 | crl\_janitor\_ingress\_ip | CRL Janitor ingress IP |
 | crl\_janitor\_fqdn | CRL Janitor fully qualified domain name |
+| crl\_janitor\_pubsub\_topic | CRL Janitor Pub/sub Topic |
+| crl\_janitor\_pubsub\_subscription | CRL Janitor Pub/sub Subscription name |
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -92,7 +92,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.8"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.1.9"
 
   enable = local.terra_apps["crl_janitor"]
 

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -142,6 +142,10 @@ output "crl_janitor_sa_id" {
   value       = module.crl_janitor.app_sa_id
   description = "CRL Janitor Google service account ID"
 }
+output "crl_janitor_sqlproxy_sa_id" {
+  value       = module.crl_janitor.sqlproxy_sa_id
+  description = "CRL Janitor Cloud SQL Proxy Google service account ID"
+}
 output "crl_janitor_client_sa_id" {
   value       = module.crl_janitor.client_sa_id
   description = "CRL Janitor Google service account ID"


### PR DESCRIPTION
-  Create cloudsql service account for Janitor.
-  Change pubsub roles to publisher/subscriber.
-  Add roles/monitoring.editor now that we're using the app sa instead of the default google sa for the k8s cluster.