### PR TITLE
DDO-634 Ontology k8s ingress

### DIFF
--- a/ontology/dns.tf
+++ b/ontology/dns.tf
@@ -1,16 +1,16 @@
 data "google_dns_managed_zone" "dns_zone" {
-  count    = var.enable && ! var.preview ? 1 : 0
+  count    = var.enable ? 1 : 0
   provider = google.dns
 
   name = var.dns_zone_name
 }
 
 locals {
-  fqdn = var.enable && ! var.preview ? "${local.hostname}${local.subdomain_name}.${data.google_dns_managed_zone.dns_zone[0].dns_name}" : null
+  fqdn = var.enable ? "${local.hostname}${local.subdomain_name}.${data.google_dns_managed_zone.dns_zone[0].dns_name}" : null
 }
 
 resource "google_dns_record_set" "ingress" {
-  count = var.enable && ! var.preview ? 1 : 0
+  count = var.enable ? 1 : 0
 
   provider     = google.dns
   managed_zone = data.google_dns_managed_zone.dns_zone[0].name

--- a/ontology/dns.tf
+++ b/ontology/dns.tf
@@ -1,0 +1,21 @@
+data "google_dns_managed_zone" "dns_zone" {
+  count    = var.enable && ! var.preview ? 1 : 0
+  provider = google.dns
+
+  name = var.dns_zone_name
+}
+
+locals {
+  fqdn = var.enable && ! var.preview ? "${local.hostname}${local.subdomain_name}.${data.google_dns_managed_zone.dns_zone[0].dns_name}" : null
+}
+
+resource "google_dns_record_set" "ingress" {
+  count = var.enable && ! var.preview ? 1 : 0
+
+  provider     = google.dns
+  managed_zone = data.google_dns_managed_zone.dns_zone[0].name
+  name         = local.fqdn
+  type         = "A"
+  ttl          = "300"
+  rrdatas      = [google_compute_address.ingress_ip[0].address]
+}

--- a/ontology/ip.tf
+++ b/ontology/ip.tf
@@ -1,0 +1,7 @@
+resource "google_compute_address" "ingress_ip" {
+  count = var.enable && ! var.preview ? 1 : 0
+
+  provider = google.target
+
+  name = "terra-${var.cluster}-${local.owner}-${local.service}-ip"
+}

--- a/ontology/ip.tf
+++ b/ontology/ip.tf
@@ -1,5 +1,5 @@
 resource "google_compute_address" "ingress_ip" {
-  count = var.enable && ! var.preview ? 1 : 0
+  count = var.enable ? 1 : 0
 
   provider = google.target
 

--- a/ontology/outputs.tf
+++ b/ontology/outputs.tf
@@ -1,0 +1,11 @@
+#
+# IP/DNS Outputs
+#
+output "ingress_ip" {
+  value       = var.enable && ! var.preview ? google_compute_address.ingress_ip[0].address : null
+  description = "Ontology ingress IP"
+}
+output "fqdn" {
+  value       = var.enable && ! var.preview ? local.fqdn : null
+  description = "Ontology fully qualified domain name"
+}

--- a/ontology/outputs.tf
+++ b/ontology/outputs.tf
@@ -2,10 +2,10 @@
 # IP/DNS Outputs
 #
 output "ingress_ip" {
-  value       = var.enable && ! var.preview ? google_compute_address.ingress_ip[0].address : null
+  value       = var.enable ? google_compute_address.ingress_ip[0].address : null
   description = "Ontology ingress IP"
 }
 output "fqdn" {
-  value       = var.enable && ! var.preview ? local.fqdn : null
+  value       = var.enable ? local.fqdn : null
   description = "Ontology fully qualified domain name"
 }

--- a/ontology/provider.tf
+++ b/ontology/provider.tf
@@ -1,0 +1,7 @@
+provider "google" {
+  alias = "target"
+}
+
+provider "google" {
+  alias = "dns"
+}

--- a/ontology/variables.tf
+++ b/ontology/variables.tf
@@ -12,11 +12,7 @@ variable "enable" {
   description = "Enable flag for this module. If set to false, no resources will be created."
   default     = true
 }
-variable "preview" {
-  type        = bool
-  description = "Preview environment flag"
-  default     = false
-}
+
 variable "google_project" {
   type        = string
   description = "The google project in which to create resources"

--- a/ontology/variables.tf
+++ b/ontology/variables.tf
@@ -1,0 +1,41 @@
+#
+# General Vars
+#
+variable "dependencies" {
+  # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
+  type        = any
+  default     = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
+}
+variable "enable" {
+  type        = bool
+  description = "Enable flag for this module. If set to false, no resources will be created."
+  default     = true
+}
+variable "preview" {
+  type        = bool
+  description = "Preview environment flag"
+  default     = false
+}
+variable "google_project" {
+  type        = string
+  description = "The google project in which to create resources"
+}
+variable "cluster" {
+  type        = string
+  description = "Terra GKE cluster suffix, whatever is after terra-"
+}
+variable "cluster_short" {
+  type        = string
+  description = "Optional short cluster name"
+  default     = ""
+}
+variable "owner" {
+  type        = string
+  description = "Environment or developer. Defaults to TF workspace name if left blank."
+  default     = ""
+}
+locals {
+  owner   = var.owner == "" ? terraform.workspace : var.owner
+  service = "ontology"
+}

--- a/ontology/variables.tf
+++ b/ontology/variables.tf
@@ -37,7 +37,7 @@ variable "owner" {
 }
 locals {
   owner   = var.owner == "" ? terraform.workspace : var.owner
-  service = "ontology"
+  service = "ontology-k8s" # K8s suffix is here for dns testing purposes, ot avoid overlap with GCE ontology, will remove when ready to cut over
 }
 
 

--- a/ontology/variables.tf
+++ b/ontology/variables.tf
@@ -39,3 +39,33 @@ locals {
   owner   = var.owner == "" ? terraform.workspace : var.owner
   service = "ontology"
 }
+
+
+#
+# DNS vars
+#
+variable "dns_zone_name" {
+  type        = string
+  description = "DNS zone name"
+  default     = "dsp-envs"
+}
+variable "use_subdomain" {
+  type        = bool
+  description = "Whether to use a subdomain between the zone and hostname"
+  default     = true
+}
+variable "subdomain_name" {
+  type        = string
+  description = "Domain namespacing between zone and hostname"
+  default     = ""
+}
+variable "hostname" {
+  type        = string
+  description = "Service hostname"
+  default     = ""
+}
+locals {
+  hostname       = var.hostname == "" ? local.service : var.hostname
+  cluster_name   = var.cluster_short == "" ? var.cluster : var.cluster_short
+  subdomain_name = var.use_subdomain ? (var.subdomain_name == "" ? ".${local.owner}.${local.cluster_name}" : var.subdomain_name) : ""
+}

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -105,7 +105,7 @@ module "crl_janitor" {
   subdomain_name = var.subdomain_name
   use_subdomain  = var.use_subdomain
 
-  google_folder_id  = var.janitor_google_folder_id
+  google_folder_id = var.janitor_google_folder_id
 
   providers = {
     google.target      = google.target
@@ -131,5 +131,25 @@ module "datarepo" {
     google.target      = google.target
     google.dns         = google.dns
     google-beta.target = google-beta.target
+  }
+}
+
+module "ontology" {
+  source = "github.com/broadinstitute/terraform-ap-modules.git//ontology?ref=DDO-634-support-ontology-k8s"
+
+  enable = local.terra_apps["ontology"]
+
+  google_project = var.google_project
+  cluster        = var.cluster
+  cluster_short  = var.cluster_short
+  preview        = var.preview
+
+  dns_zone_name  = var.dns_zone_name
+  subdomain_name = var.subdomain_name
+  use_subdomain  = var.use_subdomain
+
+  providers = {
+    google.target = google.target
+    google.dns    = google.dns
   }
 }

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -189,3 +189,16 @@ output "crl_janitor_pubsub_subscription" {
   value       = module.crl_janitor.pubsub_subscription
   description = "CRL Janitor Pub/sub Subscription name"
 }
+
+#
+# Ontology Outputs
+#
+output "ontology_ip" {
+  value       = module.ontology.ingress_ip
+  description = "Ontology service static ip"
+}
+
+output "ontology_fqdn" {
+  value       = module.ontology.fqdn
+  description = "Fqdn for the ontology service"
+}

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -65,6 +65,7 @@ locals {
     workspace_manager     = false,
     crl_janitor           = false,
     datarepo              = false,
+    ontology              = false,
     },
     var.terra_apps
   )


### PR DESCRIPTION
This pr adds support for managing ontology terraform resources. Currently it is only creating a static ip and dns record for ingress to the ontology deployment in the terra-dev cluster. The long term goal is to move all terraform resouces for the ontology service from terraform-firecloud to this workflow.