### PR TITLE
[PF-75] grant dead-letter queue permissions to Google-managed pubsub SA

### DIFF
--- a/crl-janitor/pubsub.tf
+++ b/crl-janitor/pubsub.tf
@@ -66,6 +66,12 @@ resource "google_pubsub_subscription_iam_member" "crl_janitor_client_can_manage"
   member = "serviceAccount:${google_service_account.app[0].email}"
 }
 
+// Pubsub creates a SA account for each project: service-project-number@gcp-sa-pubsub.iam.gserviceaccount.com for
+// deal lette queue message management.
+// See https://cloud.google.com/pubsub/docs/dead-letter-topics#granting_forwarding_permissions.
+data "google_project" "project" {
+}
+
 # Project SA can publish to the dead letter queue topic
 resource "google_pubsub_topic_iam_member" "crl_janitor_client_can_publish_dead_letter" {
   count = var.enable ? 1 : 0

--- a/crl-janitor/pubsub.tf
+++ b/crl-janitor/pubsub.tf
@@ -32,6 +32,21 @@ resource "google_pubsub_subscription" "crl-janitor-pubsub-subscription" {
   }
 }
 
+resource "google_pubsub_subscription" "crl-janitor-pubsub-dead-letter-subscription" {
+  count = var.enable ? 1 : 0
+
+  project = var.google_project
+  name = "${local.service}-${local.owner}-dead-letter-pubsub-sub"
+  topic = google_pubsub_topic.crl-janitor-pubsub-dead-letter-topic[0].name
+
+  ack_deadline_seconds = 20
+
+  expiration_policy {
+    // No expiration
+    ttl = ""
+  }
+}
+
 # Janitor clients can publish to the topic
 resource "google_pubsub_topic_iam_member" "crl_janitor_client_can_publish" {
   count = var.enable ? 1 : 0
@@ -49,4 +64,25 @@ resource "google_pubsub_subscription_iam_member" "crl_janitor_client_can_manage"
   subscription = google_pubsub_subscription.crl-janitor-pubsub-subscription[0].name
   role = "roles/editor"
   member   = "serviceAccount:${google_service_account.app[0].email}"
+}
+
+# Project SA can publish to the dead letter queue topic
+resource "google_pubsub_topic_iam_member" "crl_janitor_client_can_publish_dead_letter" {
+  count = var.enable ? 1 : 0
+
+  project = var.google_project
+  topic = google_pubsub_topic.crl-janitor-pubsub-dead-letter-topic[0].name
+  role = "roles/pubsub.publisher"
+
+  member   = data.google_service_account.project_pubsub_sa.email
+}
+
+# Project SA can subscribe to the dead letter queue topic
+resource "google_pubsub_subscription_iam_member" "crl_janitor_client_can_subscribe_dead_letter" {
+  count = var.enable ? 1 : 0
+
+  project = var.google_project
+  subscription = google_pubsub_subscription.crl-janitor-pubsub-dead-letter-subscription[0].name
+  role = "roles/pubsub.subscriber"
+  member   = data.google_service_account.project_pubsub_sa.email
 }

--- a/crl-janitor/pubsub.tf
+++ b/crl-janitor/pubsub.tf
@@ -54,7 +54,7 @@ resource "google_pubsub_topic_iam_member" "crl_janitor_client_can_publish" {
   project = var.google_project
   topic = google_pubsub_topic.crl-janitor-pubsub-topic[0].name
   role = "roles/pubsub.publisher"
-  member   = "serviceAccount:${google_service_account.client[0].email}"
+  member = "serviceAccount:${google_service_account.client[0].email}"
 }
 
 # Janitor SA can subscribe and forward the topic
@@ -63,7 +63,7 @@ resource "google_pubsub_subscription_iam_member" "crl_janitor_client_can_manage"
 
   subscription = google_pubsub_subscription.crl-janitor-pubsub-subscription[0].name
   role = "roles/editor"
-  member   = "serviceAccount:${google_service_account.app[0].email}"
+  member = "serviceAccount:${google_service_account.app[0].email}"
 }
 
 # Project SA can publish to the dead letter queue topic
@@ -73,16 +73,14 @@ resource "google_pubsub_topic_iam_member" "crl_janitor_client_can_publish_dead_l
   project = var.google_project
   topic = google_pubsub_topic.crl-janitor-pubsub-dead-letter-topic[0].name
   role = "roles/pubsub.publisher"
-
-  member   = data.google_service_account.project_pubsub_sa.email
+  member = "serviceAccount:${data.google_service_account.project_pubsub_sa.email}"
 }
 
 # Project SA can subscribe to the dead letter queue topic
 resource "google_pubsub_subscription_iam_member" "crl_janitor_client_can_subscribe_dead_letter" {
   count = var.enable ? 1 : 0
-
   project = var.google_project
   subscription = google_pubsub_subscription.crl-janitor-pubsub-dead-letter-subscription[0].name
   role = "roles/pubsub.subscriber"
-  member   = data.google_service_account.project_pubsub_sa.email
+  member = "serviceAccount:${data.google_service_account.project_pubsub_sa.email}"
 }

--- a/crl-janitor/pubsub.tf
+++ b/crl-janitor/pubsub.tf
@@ -73,7 +73,7 @@ resource "google_pubsub_topic_iam_member" "crl_janitor_client_can_publish_dead_l
   project = var.google_project
   topic = google_pubsub_topic.crl-janitor-pubsub-dead-letter-topic[0].name
   role = "roles/pubsub.publisher"
-  member = "serviceAccount:${data.google_service_account.project_pubsub_sa.email}"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
 # Project SA can subscribe to the dead letter queue topic
@@ -82,5 +82,5 @@ resource "google_pubsub_subscription_iam_member" "crl_janitor_client_can_subscri
   project = var.google_project
   subscription = google_pubsub_subscription.crl-janitor-pubsub-dead-letter-subscription[0].name
   role = "roles/pubsub.subscriber"
-  member = "serviceAccount:${data.google_service_account.project_pubsub_sa.email}"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }

--- a/crl-janitor/pubsub.tf
+++ b/crl-janitor/pubsub.tf
@@ -82,11 +82,11 @@ resource "google_pubsub_topic_iam_member" "crl_janitor_client_can_publish_dead_l
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
-# Project SA can subscribe to the dead letter queue topic
-resource "google_pubsub_subscription_iam_member" "crl_janitor_client_can_subscribe_dead_letter" {
+# Project SA can subscribe to topic then forward the message.
+resource "google_pubsub_subscription_iam_member" "crl_janitor_client_can_subscribe" {
   count = var.enable ? 1 : 0
   project = var.google_project
-  subscription = google_pubsub_subscription.crl-janitor-pubsub-dead-letter-subscription[0].name
+  subscription = google_pubsub_subscription.crl-janitor-pubsub-subscription[0].name
   role = "roles/pubsub.subscriber"
   member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }

--- a/crl-janitor/sa.tf
+++ b/crl-janitor/sa.tf
@@ -80,5 +80,5 @@ output "project_number" {
 // deal lette queue message management.
 // See https://cloud.google.com/pubsub/docs/dead-letter-topics#granting_forwarding_permissions.
 data "google_service_account" "project_pubsub_sa" {
-  account_id = join(["service-", data.google_project.project.number]
+  account_id = concat("service-", data.google_project.project.number)
 }

--- a/crl-janitor/sa.tf
+++ b/crl-janitor/sa.tf
@@ -80,5 +80,5 @@ output "project_number" {
 // deal lette queue message management.
 // See https://cloud.google.com/pubsub/docs/dead-letter-topics#granting_forwarding_permissions.
 data "google_service_account" "project_pubsub_sa" {
-  account_id = concat("service-", data.google_project.project.number)
+  account_id = "service-${data.google_project.project.number}"
 }

--- a/crl-janitor/sa.tf
+++ b/crl-janitor/sa.tf
@@ -80,5 +80,5 @@ output "project_number" {
 // deal lette queue message management.
 // See https://cloud.google.com/pubsub/docs/dead-letter-topics#granting_forwarding_permissions.
 data "google_service_account" "project_pubsub_sa" {
-  account_id = "service-" + data.google_project.project.number
+  account_id = join(["service-", data.google_project.project.number]
 }

--- a/crl-janitor/sa.tf
+++ b/crl-janitor/sa.tf
@@ -68,17 +68,3 @@ resource "google_service_account" "client" {
   account_id   = "${local.service}-client-${local.owner}"
   display_name = "${local.service}-client-${local.owner}"
 }
-
-data "google_project" "project" {
-}
-
-output "project_number" {
-  value = data.google_project.project.number
-}
-
-// Pubsub creates a SA account for each project: service-project-number@gcp-sa-pubsub.iam.gserviceaccount.com for
-// deal lette queue message management.
-// See https://cloud.google.com/pubsub/docs/dead-letter-topics#granting_forwarding_permissions.
-data "google_service_account" "project_pubsub_sa" {
-  account_id = "service-${data.google_project.project.number}"
-}

--- a/crl-janitor/sa.tf
+++ b/crl-janitor/sa.tf
@@ -68,3 +68,17 @@ resource "google_service_account" "client" {
   account_id   = "${local.service}-client-${local.owner}"
   display_name = "${local.service}-client-${local.owner}"
 }
+
+data "google_project" "project" {
+}
+
+output "project_number" {
+  value = data.google_project.project.number
+}
+
+// Pubsub creates a SA account for each project: service-project-number@gcp-sa-pubsub.iam.gserviceaccount.com for
+// deal lette queue message management.
+// See https://cloud.google.com/pubsub/docs/dead-letter-topics#granting_forwarding_permissions.
+data "google_service_account" "project_pubsub_sa" {
+  account_id = "service-" + data.google_project.project.number
+}

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -93,7 +93,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=yyu-PF-75-2"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.2.2"
 
   enable = local.terra_apps["crl_janitor"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -93,7 +93,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.2.1"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=yyu-PF-75-2"
 
   enable = local.terra_apps["crl_janitor"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -93,7 +93,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.2.2"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=yyu-PF-75-2"
 
   enable = local.terra_apps["crl_janitor"]
 


### PR DESCRIPTION
Context: To use pubsub queue, we need to grant publisher and subscriber permission to the `pubsub created` SA account. 
The SA account is not created via Terraform, but by pubsub, the format is `service-project-number@gcp-sa-pubsub.iam.gserviceaccount.com`

See https://cloud.google.com/pubsub/docs/dead-letter-topics for more details. 