### PR TITLE
PF-4 Enable billing api and give billing role to SA on crl-test.

### DIFF
--- a/crl-test/README.md
+++ b/crl-test/README.md
@@ -17,8 +17,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| google | n/a |
 | google.target | n/a |
+| google | n/a |
 
 ## Inputs
 
@@ -27,6 +27,7 @@ No requirements.
 | google\_project | The google project id to create for CRL to run integration tests within. | `string` | n/a | yes |
 | folder\_id | What folder to create google\_project and a test folder under. | `string` | n/a | yes |
 | billing\_account\_id | What billing account to assign to the project. | `string` | n/a | yes |
+| enable\_billing\_user | Whether to set the CRL test SA as a billing user on the billing account. | `boolean` | `true` | no |
 
 ## Outputs
 

--- a/crl-test/api-services.tf
+++ b/crl-test/api-services.tf
@@ -14,5 +14,6 @@ module "enable-services" {
     "storage-api.googleapis.com",
     "storage-component.googleapis.com",
     "bigquery.googleapis.com",
+    "cloudbilling.googleapis.com",
   ]
 }

--- a/crl-test/folder.tf
+++ b/crl-test/folder.tf
@@ -2,7 +2,7 @@
 # We create a separate folder to scope the CRL test SA broad folder permissions to a single purpose folder.
 resource "google_folder" "test_resource_container" {
   display_name = "CRL Test resource container"
-  parent = "folders/${var.folder_id}"
+  parent       = "folders/${var.folder_id}"
 
   provider = google.target
 }

--- a/crl-test/outputs.tf
+++ b/crl-test/outputs.tf
@@ -1,5 +1,5 @@
 output "test_resource_container_folder_id" {
-  value = google_folder.test_resource_container.id
+  value       = google_folder.test_resource_container.id
   description = "The folder id of the folder the admin service account has permissions to edit."
 }
 

--- a/crl-test/service_accounts.tf
+++ b/crl-test/service_accounts.tf
@@ -20,7 +20,6 @@ locals {
     # Roles used in integration testing.
     "roles/storage.admin",
     "roles/bigquery.admin",
-    "roles/billing.projectManager",
   ]
 
   # Roles used to manage projects for integration testing.
@@ -44,4 +43,10 @@ resource "google_folder_iam_member" "app_folder_roles" {
   folder  = google_folder.test_resource_container.id
   role     = local.folder_roles[count.index]
   member   = "serviceAccount:${google_service_account.crl_test_admin.email}"
+}
+
+resource "google_billing_account_iam_member" "crl_test_admin" {
+  billing_account_id = var.billing_account_id
+  role               = "roles/billing.user"
+  member             = "serviceAccount:${google_service_account.crl_test_admin.email}"
 }

--- a/crl-test/service_accounts.tf
+++ b/crl-test/service_accounts.tf
@@ -20,7 +20,7 @@ locals {
     # Roles used in integration testing.
     "roles/storage.admin",
     "roles/bigquery.admin",
-    "roles/billing.user",
+    "roles/billing.projectManager",
   ]
 
   # Roles used to manage projects for integration testing.

--- a/crl-test/service_accounts.tf
+++ b/crl-test/service_accounts.tf
@@ -38,14 +38,15 @@ resource "google_project_iam_member" "crl_test_admin" {
 }
 
 resource "google_folder_iam_member" "app_folder_roles" {
-  count = length(local.folder_roles)
+  count    = length(local.folder_roles)
   provider = google.target
-  folder  = google_folder.test_resource_container.id
+  folder   = google_folder.test_resource_container.id
   role     = local.folder_roles[count.index]
   member   = "serviceAccount:${google_service_account.crl_test_admin.email}"
 }
 
 resource "google_billing_account_iam_member" "crl_test_admin" {
+  count              = var.enable_billing_user ? 1 : 0
   billing_account_id = var.billing_account_id
   role               = "roles/billing.user"
   member             = "serviceAccount:${google_service_account.crl_test_admin.email}"

--- a/crl-test/service_accounts.tf
+++ b/crl-test/service_accounts.tf
@@ -18,6 +18,7 @@ locals {
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
     # Roles used in integration testing.
+    "roles/billing.user",
     "roles/storage.admin",
     "roles/bigquery.admin",
   ]

--- a/crl-test/service_accounts.tf
+++ b/crl-test/service_accounts.tf
@@ -18,9 +18,9 @@ locals {
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
     # Roles used in integration testing.
-    "roles/billing.user",
     "roles/storage.admin",
     "roles/bigquery.admin",
+    "roles/billing.user",
   ]
 
   # Roles used to manage projects for integration testing.

--- a/crl-test/variables.tf
+++ b/crl-test/variables.tf
@@ -17,7 +17,7 @@ variable "billing_account_id" {
 # Broad SA that runs terraform does not want to have the broad permissions to set modify
 # permissions on the service account. This was done manually instead for the Broad.
 variable "enable_billing_user" {
-  type        = boolean
+  type        = bool
   description = "Whether to set the CRL test SA as a billing user on the billing account."
   default     = true
 }

--- a/crl-test/variables.tf
+++ b/crl-test/variables.tf
@@ -12,3 +12,12 @@ variable "billing_account_id" {
   type        = string
   description = "What billing account to assign to the project."
 }
+
+# We separate whether the roles/billing.user is set on the CRL test SA as its own flag because the
+# Broad SA that runs terraform does not want to have the broad permissions to set modify
+# permissions on the service account. This was done manually instead for the Broad.
+variable "enable_billing_user" {
+  type        = boolean
+  description = "Whether to set the CRL test SA as a billing user on the billing account."
+  default     = true
+}


### PR DESCRIPTION
Gives the crl test SA roles/billing.user on the billing account used for its project and folder. This is a restrictive role: https://cloud.google.com/billing/docs/how-to/billing-access#overview-of-cloud-billing-roles-in-cloud-iam