### PR TITLE
[PF-24] Grant crl janitor SApermission to be able to delete dataset

### DIFF
--- a/crl-janitor/sa.tf
+++ b/crl-janitor/sa.tf
@@ -32,6 +32,7 @@ locals {
     "roles/editor",
     # Allow deleting project.
     "roles/resourcemanager.projectDeleter",
+    "roles/bigquery.admin",
   ]
 }
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -93,7 +93,8 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.2.5"
+  // source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.2.6"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-yyu-PF-24-3"
 
   enable = local.terra_apps["crl_janitor"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -93,8 +93,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  // source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.2.6"
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=yyu-PF-24-3"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.2.6"
 
   enable = local.terra_apps["crl_janitor"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -94,7 +94,7 @@ module "workspace_manager" {
 
 module "crl_janitor" {
   // source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.2.6"
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-yyu-PF-24-3"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=yyu-PF-24-3"
 
   enable = local.terra_apps["crl_janitor"]
 


### PR DESCRIPTION
The editor role doesn't have permission to delete dataset:
https://cloud.google.com/bigquery/docs/access-control-primitive-roles
We need to give it bigquery.admin role as well