### PR TITLE
DDO-712 CIS compliance updates

### DIFF
--- a/terra-cluster/k8s-master.tf
+++ b/terra-cluster/k8s-master.tf
@@ -1,6 +1,6 @@
 module "k8s-master" {
   # terraform-shared repo
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-master?ref=k8s-master-0.2.2-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-master?ref=ch-ddo-712"
   dependencies = [
     module.enable-services,
     google_compute_network.k8s-cluster-network
@@ -23,4 +23,6 @@ module "k8s-master" {
   }
 
   istio_enable = var.istio_enable
+
+  enable_shielded_nodes = true
 }

--- a/terra-cluster/k8s-master.tf
+++ b/terra-cluster/k8s-master.tf
@@ -1,6 +1,6 @@
 module "k8s-master" {
   # terraform-shared repo
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-master?ref=ch-ddo-712"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-master?ref=k8s-master-0.2.3-tf-0.12"
   dependencies = [
     module.enable-services,
     google_compute_network.k8s-cluster-network

--- a/terra-cluster/sa.tf
+++ b/terra-cluster/sa.tf
@@ -28,8 +28,6 @@ locals {
     "roles/monitoring.viewer",
     "roles/monitoring.metricWriter",
     "roles/logging.logWriter",
-    # Google Container Registry read access.
-    "roles/storage.objectViewer"
   ]
 }
 


### PR DESCRIPTION
* Remove storage.objectViewer on the project that hosts the GKE cluster (not needed)
* Enable Shielded Nodes: https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes