### PR TITLE
DDO-803 Initial setup for consent k8s deployment

### DIFF
--- a/consent/README.md
+++ b/consent/README.md
@@ -1,0 +1,41 @@
+# Terra consent module
+
+For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)  
+and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+
+This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+`terraform-docs markdown --no-sort . > README.md`
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google.dns | n/a |
+| google.target | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| dependencies | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
+| enable | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
+| google\_project | The google project in which to create resources | `string` | n/a | yes |
+| cluster | Terra GKE cluster suffix, whatever is after terra- | `string` | n/a | yes |
+| cluster\_short | Optional short cluster name | `string` | `""` | no |
+| owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
+| dns\_zone\_name | DNS zone name | `string` | `"dsp-envs"` | no |
+| use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
+| subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
+| hostname | Service hostname | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ingress\_ip | Consent ingress IP |
+| fqdn | Consent fully qualified domain name |
+

--- a/consent/dns.tf
+++ b/consent/dns.tf
@@ -1,0 +1,21 @@
+data "google_dns_managed_zone" "dns_zone" {
+  count    = var.enable ? 1 : 0
+  provider = google.dns
+
+  name = var.dns_zone_name
+}
+
+locals {
+  fqdn = var.enable ? "${local.hostname}${local.subdomain_name}.${data.google_dns_managed_zone.dns_zone[0].dns_name}" : null
+}
+
+resource "google_dns_record_set" "ingress" {
+  count = var.enable ? 1 : 0
+
+  provider     = google.dns
+  managed_zone = data.google_dns_managed_zone.dns_zone[0].name
+  name         = local.fqdn
+  type         = "A"
+  ttl          = "300"
+  rrdatas      = [google_compute_address.ingress_ip[0].address]
+}

--- a/consent/ip.tf
+++ b/consent/ip.tf
@@ -1,0 +1,7 @@
+resource "google_compute_address" "ingress_ip" {
+  count = var.enable ? 1 : 0
+
+  provider = google.target
+
+  name = "terra-${var.cluster}-${local.owner}-${local.service}-ip"
+}

--- a/consent/main.tf
+++ b/consent/main.tf
@@ -1,0 +1,9 @@
+/**
+ * # Terra consent module
+ * 
+ * For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
+ * and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+ *
+ * This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+ * `terraform-docs markdown --no-sort . > README.md`
+ */

--- a/consent/outputs.tf
+++ b/consent/outputs.tf
@@ -1,0 +1,11 @@
+#
+# IP/DNS Outputs
+#
+output "ingress_ip" {
+  value       = var.enable ? google_compute_address.ingress_ip[0].address : null
+  description = "Consent ingress IP"
+}
+output "fqdn" {
+  value       = var.enable ? local.fqdn : null
+  description = "Consent fully qualified domain name"
+}

--- a/consent/provider.tf
+++ b/consent/provider.tf
@@ -1,0 +1,7 @@
+provider "google" {
+  alias = "target"
+}
+
+provider "google" {
+  alias = "dns"
+}

--- a/consent/variables.tf
+++ b/consent/variables.tf
@@ -1,0 +1,67 @@
+#
+# General Vars
+#
+variable "dependencies" {
+  # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
+  type        = any
+  default     = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
+}
+variable "enable" {
+  type        = bool
+  description = "Enable flag for this module. If set to false, no resources will be created."
+  default     = true
+}
+
+variable "google_project" {
+  type        = string
+  description = "The google project in which to create resources"
+}
+variable "cluster" {
+  type        = string
+  description = "Terra GKE cluster suffix, whatever is after terra-"
+}
+variable "cluster_short" {
+  type        = string
+  description = "Optional short cluster name"
+  default     = ""
+}
+variable "owner" {
+  type        = string
+  description = "Environment or developer. Defaults to TF workspace name if left blank."
+  default     = ""
+}
+locals {
+  owner   = var.owner == "" ? terraform.workspace : var.owner
+  service = "consent-k8s" # K8s suffix is here for dns testing purposes, ot avoid overlap with GCE consent, will remove when ready to cut over
+}
+
+
+#
+# DNS vars
+#
+variable "dns_zone_name" {
+  type        = string
+  description = "DNS zone name"
+  default     = "dsp-envs"
+}
+variable "use_subdomain" {
+  type        = bool
+  description = "Whether to use a subdomain between the zone and hostname"
+  default     = true
+}
+variable "subdomain_name" {
+  type        = string
+  description = "Domain namespacing between zone and hostname"
+  default     = ""
+}
+variable "hostname" {
+  type        = string
+  description = "Service hostname"
+  default     = ""
+}
+locals {
+  hostname       = var.hostname == "" ? local.service : var.hostname
+  cluster_name   = var.cluster_short == "" ? var.cluster : var.cluster_short
+  subdomain_name = var.use_subdomain ? (var.subdomain_name == "" ? ".${local.owner}.${local.cluster_name}" : var.subdomain_name) : ""
+}

--- a/terra-env/README.md
+++ b/terra-env/README.md
@@ -35,12 +35,18 @@ No provider.
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
 | wsm\_db\_version | The version for the WSM CloudSQL instance | `string` | `"POSTGRES_9_6"` | no |
 | wsm\_db\_keepers | Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility | `bool` | `false` | no |
-| datarepo\_dns\_name | Name for the Data Repo DNS record. Eg. data.alpha | `string` | `""` | no |
+| datarepo\_dns\_name | DNS record name, excluding zone top-level domain. Eg. data.alpha | `string` | `""` | no |
+| grafana\_dns\_name | DNS record name, excluding zone top-level domain. Eg. data.alpha | `string` | `""` | no |
+| prometheus\_dns\_name | DNS record name, excluding zone top-level domain. Eg. data.alpha | `string` | `""` | no |
 | datarepo\_dns\_zone\_name | Zone where Data Repo DNS record should be provisioned | `string` | `""` | no |
 | datarepo\_dns\_zone\_project | Google Project where Data Repo DNS zone lives | `string` | `""` | no |
 | datarepo\_static\_ip\_name | Name of Data Repo's static IP | `string` | `""` | no |
+| grafana\_static\_ip\_name | Name of Data Repo's static IP | `string` | `""` | no |
+| prometheus\_static\_ip\_name | Name of Data Repo's static IP | `string` | `""` | no |
 | datarepo\_static\_ip\_project | Project where of Data Repo's static IP lives | `string` | `""` | no |
 | janitor\_google\_folder\_id | The folder ID in which Janitor has permission to cleanup resources. | `string` | `""` | no |
+| rbs\_google\_folder\_id | The folder ID in which RBS has permission | `string` | `""` | no |
+| rbs\_billing\_account\_id | The billing account ID RBS has permission to use | `string` | `""` | no |
 
 ## Outputs
 
@@ -99,4 +105,6 @@ No provider.
 | rbs\_stairway\_db\_creds | Terra RBS Stairway database user credentials |
 | rbs\_ingress\_ip | Terra RBS ingress IP |
 | rbs\_fqdn | Terra RBS fully qualified domain name |
+| consent\_ingress\_ip | Static ip for consent LB |
+| consent\_fqdn | fqdn for to access k8s consent deployment |
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -189,7 +189,7 @@ module "rbs" {
 module "consent" {
   source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=DDO-803-consent-k8s-initial"
 
-  enable = loacl.terra_apps["consent"]
+  enable = local.terra_apps["consent"]
 
   google_project = var.google_project
   cluster        = var.cluster

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -187,7 +187,7 @@ module "rbs" {
 }
 
 module "consent" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=DDO-803-consent-k8s-initial"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=consent-0.0.2"
 
   enable = local.terra_apps["consent"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -128,13 +128,13 @@ module "datarepo" {
   grafana_dns_name    = var.grafana_dns_name
   prometheus_dns_name = var.prometheus_dns_name
   # dns zone and project
-  dns_zone_name       = var.datarepo_dns_zone_name
-  dns_zone_project    = var.datarepo_dns_zone_project
+  dns_zone_name             = var.datarepo_dns_zone_name
+  dns_zone_project          = var.datarepo_dns_zone_project
   datarepo_static_ip_name   = var.datarepo_static_ip_name
   grafana_static_ip_name    = var.grafana_static_ip_name
   prometheus_static_ip_name = var.prometheus_static_ip_name
 
-  static_ip_project         = var.datarepo_static_ip_project
+  static_ip_project = var.datarepo_static_ip_project
 
   providers = {
     google.target      = google.target
@@ -183,5 +183,24 @@ module "rbs" {
     google.target      = google.target
     google.dns         = google.dns
     google-beta.target = google-beta.target
+  }
+}
+
+module "consent" {
+  source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=DDO-803-consent-k8s-initial"
+
+  enable = loacl.terra_apps["consent"]
+
+  google_project = var.google_project
+  cluster        = var.cluster
+  cluster_short  = var.cluster_short
+
+  dns_zone_name  = var.dns_zone_name
+  subdomain_name = var.subdomain_name
+  use_subdomain  = var.use_subdomain
+
+  providers = {
+    google.target = google.target
+    google.dns    = google.dns
   }
 }

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -210,13 +210,13 @@ output "versions" {
   description = "Base64 encoded JSON string of version overrides"
 }
 output "ingress_ips" {
-  value       = contains(["preview"], var.env_type) ? {
+  value = contains(["preview"], var.env_type) ? {
     workspacemanager = local.terra_apps["workspace_manager"] ? module.workspace_manager.ingress_ip : null
   } : null
   description = "Service ingress IPs"
 }
 output "fqdns" {
-  value       = contains(["preview"], var.env_type) ? {
+  value = contains(["preview"], var.env_type) ? {
     workspacemanager = local.terra_apps["workspace_manager"] ? module.workspace_manager.fqdn : null
   } : null
   description = "Service fully qualified domain names"
@@ -263,4 +263,17 @@ output "rbs_ingress_ip" {
 output "rbs_fqdn" {
   value       = module.rbs.fqdn
   description = "Terra RBS fully qualified domain name"
+}
+
+#
+# Consent Outputs
+#
+output "consent_ingress_ip" {
+  value       = module.consent.ingress_ip
+  description = "Static ip for consent LB"
+}
+
+output "consent_fqdn" {
+  value       = module.consent.fqdn
+  description = "fqdn for to access k8s consent deployment"
 }

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -59,9 +59,9 @@ variable "env_type" {
 # Preview environment Vars
 #
 variable "versions" {
-  type = string
+  type        = string
   description = "Base64 encoded JSON string of version overrides. Used for preview environments."
-  default = "eyJyZWxlYXNlcyI6e319Cg=="
+  default     = "eyJyZWxlYXNlcyI6e319Cg=="
 }
 
 
@@ -84,6 +84,7 @@ locals {
     datarepo              = false,
     ontology              = false,
     rbs                   = false,
+    consent               = false,
     },
     var.terra_apps
   )
@@ -191,7 +192,7 @@ variable "rbs_google_folder_id" {
   description = "The folder ID in which RBS has permission"
 }
 variable "rbs_billing_account_id" {
-  type        = string
+  type = string
   # If billing_account_id is empty, we won't set the RBS SA as a billing user
   default     = ""
   description = "The billing account ID RBS has permission to use"


### PR DESCRIPTION
This pr performs inital setup for exposing the dev k8s deployment of consent. 
It creates a static ip for the load-balanced service and a temporary dns name so
that the GKE deployment will not conflict with the GCE﻿
