### PR TITLE
PF-152 Give Workspace Manager SA project creation permissions & apis.

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -69,9 +69,7 @@ module "sam_persistence" {
 }
 
 module "workspace_manager" {
-  # DO NOT SUBMIT use github tag.
-  source = "../terra-workspace-manager"
-  #source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.3.2"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.0"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -89,7 +89,7 @@ module "workspace_manager" {
   db_keepers = var.wsm_db_keepers
 
   workspace_project_folder_id = var.wsm_workspace_project_folder_id
-  billing_account_ids = var.wsm_billing_account_ids
+  billing_account_ids         = var.wsm_billing_account_ids
 
   providers = {
     google.target      = google.target

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -69,7 +69,9 @@ module "sam_persistence" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.3.2"
+  # DO NOT SUBMIT use github tag.
+  source = "../terra-workspace-manager"
+  #source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.3.2"
 
   enable = local.terra_apps["workspace_manager"]
 
@@ -85,6 +87,9 @@ module "workspace_manager" {
 
   db_version = var.wsm_db_version
   db_keepers = var.wsm_db_keepers
+
+  workspace_project_folder_id = var.wsm_workspace_project_folder_id
+  billing_account_ids = var.wsm_billing_account_ids
 
   providers = {
     google.target      = google.target

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -99,6 +99,10 @@ output "workspace_sqlproxy_sa_id" {
   value       = module.workspace_manager.sqlproxy_sa_id
   description = "Workspace Manager Cloud SQL Proxy Google service account ID"
 }
+output "workspace_app_sa_id" {
+  value       = module.workspace_manager.app_sa_id
+  description = "Workspace Manager App Google service account ID"
+}
 output "workspace_cloud_trace_sa_id" {
   value       = module.workspace_manager.cloud_trace_sa_id
   description = "Workspace Manager Cloud trace Google service account ID"

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -113,13 +113,14 @@ variable "use_subdomain" {
 # Workspace Manager Vars
 #
 variable "wsm_workspace_project_folder_id" {
-  type = string
+  type        = string
   description = "What google folder within which to create a folder for creating workspace google projects."
+  default     = null
 }
 variable "wsm_billing_account_ids" {
-  type = list(string)
+  type        = list(string)
   description = "List of Google billing account ids to allow WM to use for billing workspace google projects."
-  default = []
+  default     = []
 }
 variable "wsm_db_version" {
   type        = string

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -112,6 +112,15 @@ variable "use_subdomain" {
 #
 # Workspace Manager Vars
 #
+variable "wsm_workspace_project_folder_id" {
+  type = string
+  description = "What google folder within which to create a folder for creating workspace google projects."
+}
+variable "wsm_billing_account_ids" {
+  type = list(string)
+  description = "List of Google billing account ids to allow WM to use for billing workspace google projects."
+  default = []
+}
 variable "wsm_db_version" {
   type        = string
   default     = "POSTGRES_9_6"

--- a/terra-workspace-manager/README.md
+++ b/terra-workspace-manager/README.md
@@ -21,6 +21,7 @@ No requirements.
 |------|---------|
 | google.dns | n/a |
 | google.target | n/a |
+| google | n/a |
 
 ## Inputs
 
@@ -33,6 +34,8 @@ No requirements.
 | cluster\_short | Optional short cluster name | `string` | `""` | no |
 | owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
 | env\_type | Environment type. Valid values are 'preview', 'preview\_shared', and 'default' | `string` | `"default"` | no |
+| workspace\_project\_folder\_id | What google folder within which to create a folder for creating workspace google projects. | `string` | `null` | no |
+| billing\_account\_ids | List of Google billing account ids to allow WSM to use for billing workspace google projects. | `list(string)` | `[]` | no |
 | dns\_zone\_name | DNS zone name | `string` | `"dsp-envs"` | no |
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
 | subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
@@ -50,6 +53,7 @@ No requirements.
 | Name | Description |
 |------|-------------|
 | sqlproxy\_sa\_id | Workspace Manager Cloud SQL Proxy Google service account ID |
+| app\_sa\_id | Workspace Manager App Google service account ID |
 | cloud\_trace\_sa\_id | Workspace Manager Cloud trace Google service account ID |
 | ingress\_ip | Workspace Manager ingress IP |
 | fqdn | Workspace Manager fully qualified domain name |

--- a/terra-workspace-manager/api-services.tf
+++ b/terra-workspace-manager/api-services.tf
@@ -1,0 +1,16 @@
+module "enable-services" {
+  source      = "github.com/broadinstitute/terraform-shared.git//terraform-modules/api-services?ref=services-0.3.0-tf-0.12"
+  enable_flag = var.enable && contains(["default", "preview_shared"], var.env_type)
+  providers = {
+    google.target = google.target
+  }
+  project = google_project
+  services = [
+    "cloudbilling.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "storage-api.googleapis.com",
+    "storage-component.googleapis.com",
+  ]
+}

--- a/terra-workspace-manager/api-services.tf
+++ b/terra-workspace-manager/api-services.tf
@@ -4,7 +4,7 @@ module "enable-services" {
   providers = {
     google.target = google.target
   }
-  project = google_project
+  project = var.google_project
   services = [
     "cloudbilling.googleapis.com",
     "cloudresourcemanager.googleapis.com",

--- a/terra-workspace-manager/api-services.tf
+++ b/terra-workspace-manager/api-services.tf
@@ -8,6 +8,7 @@ module "enable-services" {
   services = [
     "cloudbilling.googleapis.com",
     "cloudresourcemanager.googleapis.com",
+    "cloudtrace.googleapis.com",
     "logging.googleapis.com",
     "monitoring.googleapis.com",
     "storage-api.googleapis.com",

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -6,8 +6,8 @@ module "cloudsql" {
   providers = {
     google.target = google.target
   }
-  project       = var.google_project
-  cloudsql_name = "${local.service}-db-${local.owner}"
+  project          = var.google_project
+  cloudsql_name    = "${local.service}-db-${local.owner}"
   cloudsql_version = var.db_version
   cloudsql_keepers = var.db_keepers
   cloudsql_instance_labels = {

--- a/terra-workspace-manager/folder.tf
+++ b/terra-workspace-manager/folder.tf
@@ -1,0 +1,9 @@
+# Folder used to contain projects created by WM.
+# We create a separate folder to scope the WM SA broad folder permissions to a single purpose folder.
+# TODO(PF-156): Once WM uses RBS, we no longer need permissions to create projects, or this folder.
+resource "google_folder" "workspace_project_folder" {
+  count    = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != null ? 1 : 0
+  display_name = "Workspace Manager workspace project folder"
+  parent       = "folders/${var.workspace_project_folder_id}"
+  provider = google.target
+}

--- a/terra-workspace-manager/folder.tf
+++ b/terra-workspace-manager/folder.tf
@@ -3,7 +3,7 @@
 # TODO(PF-156): Once WM uses RBS, we no longer need permissions to create projects, or this folder.
 resource "google_folder" "workspace_project_folder" {
   count        = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != null ? 1 : 0
-  display_name = "Workspace Manager workspace project folder"
+  display_name = "${local.service}-${local.owner} workspace project folder"
   parent       = "folders/${var.workspace_project_folder_id}"
   provider     = google.target
 }

--- a/terra-workspace-manager/folder.tf
+++ b/terra-workspace-manager/folder.tf
@@ -2,8 +2,8 @@
 # We create a separate folder to scope the WM SA broad folder permissions to a single purpose folder.
 # TODO(PF-156): Once WM uses RBS, we no longer need permissions to create projects, or this folder.
 resource "google_folder" "workspace_project_folder" {
-  count    = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != null ? 1 : 0
+  count        = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != null ? 1 : 0
   display_name = "Workspace Manager workspace project folder"
   parent       = "folders/${var.workspace_project_folder_id}"
-  provider = google.target
+  provider     = google.target
 }

--- a/terra-workspace-manager/outputs.tf
+++ b/terra-workspace-manager/outputs.tf
@@ -2,11 +2,15 @@
 # Service Account Outputs
 #
 output "sqlproxy_sa_id" {
-  value       = var.enable && contains(["default"], var.env_type) ? google_service_account.sqlproxy[0].account_id : null
+  value       = length(google_service_account.sqlproxy) > 0 ? google_service_account.sqlproxy[0].account_id : null
   description = "Workspace Manager Cloud SQL Proxy Google service account ID"
 }
+output "app_sa_id" {
+  value       = length(google_service_account.app) > 0 ? google_service_account.app[0].account_id : null
+  description = "Workspace Manager App Google service account ID"
+}
 output "cloud_trace_sa_id" {
-  value       = var.enable && contains(["default", "preview_shared"], var.env_type) ? google_service_account.cloud_trace[0].account_id : null
+  value       = length(google_service_account.cloud_trace) > 0 ? google_service_account.cloud_trace[0].account_id : null
   description = "Workspace Manager Cloud trace Google service account ID"
 }
 

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -50,7 +50,7 @@ resource "google_project_iam_member" "app" {
   member   = "serviceAccount:${google_service_account.app[0].email}"
 }
 resource "google_folder_iam_member" "app" {
-  count    = var.enable && contains(["default", "preview_shared"], var.env_type) ? length(local.app_folder_roles) : 0
+  count    = length(google_folder.workspace_project_folder) > 0 ? length(local.app_folder_roles) : 0
   provider = google.target
   folder   = google_folder.workspace_project_folder[0].id
   role     = local.app_folder_roles[count.index]

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -9,7 +9,7 @@ resource "google_service_account" "sqlproxy" {
 }
 resource "google_project_iam_member" "sqlproxy" {
   count = var.enable && contains(["default"], var.env_type) ? 1 : 0
-  
+
   provider = google.target
   project  = var.google_project
   role     = "roles/cloudsql.client"
@@ -43,15 +43,14 @@ resource "google_service_account" "app" {
 }
 
 resource "google_billing_account_iam_member" "crl_test_admin" {
-  count              = var.enable && contains(["default", "preview_shared"], var.env_type) ? length
-  (var.billing_account_ids) : 0
+  count              = var.enable && contains(["default", "preview_shared"], var.env_type) ? length(var.billing_account_ids) : 0
   billing_account_id = var.billing_account_ids[count.index]
   role               = "roles/billing.user"
   member             = "serviceAccount:${google_service_account.app.email}"
 }
 
 resource "google_folder_iam_member" "app_folder_roles" {
-  count    = var.enable && contains(["default", "preview_shared"], var.env_type)? length(local.app_folder_roles) : 0
+  count    = var.enable && contains(["default", "preview_shared"], var.env_type) ? length(local.app_folder_roles) : 0
   provider = google.target
   folder   = google_folder.workspace_project_folder.id
   role     = local.app_folder_roles[count.index]

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -43,14 +43,14 @@ resource "google_service_account" "app" {
 }
 
 resource "google_project_iam_member" "app" {
-  count = var.enable && contains(["default", "preview_shared"], var.env_type) ? length(local.app_sa_roles) : 0
+  count    = var.enable && contains(["default", "preview_shared"], var.env_type) ? length(local.app_sa_roles) : 0
   provider = google.target
   project  = var.google_project
   role     = local.app_sa_roles[count.index]
   member   = "serviceAccount:${google_service_account.app[0].email}"
 }
 resource "google_folder_iam_member" "app" {
-  count    = length(google_folder.workspace_project_folder) > 0 ? length(local.app_folder_roles) : 0
+  count    = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != null ? length(local.app_folder_roles) : 0
   provider = google.target
   folder   = google_folder.workspace_project_folder[0].id
   role     = local.app_folder_roles[count.index]

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -1,3 +1,4 @@
+# The service account for the cloudsql proxy.
 resource "google_service_account" "sqlproxy" {
   count = var.enable && contains(["default"], var.env_type) ? 1 : 0
 
@@ -15,6 +16,49 @@ resource "google_project_iam_member" "sqlproxy" {
   member   = "serviceAccount:${google_service_account.sqlproxy[0].email}"
 }
 
+locals {
+  app_sa_roles = [
+    # Allow exporting metrics, profiling, and tracing for monitoring.
+    "roles/monitoring.editor",
+    "roles/cloudprofiler.agent",
+    "roles/cloudtrace.agent",
+  ]
+
+  # Roles used to manage created workspace projects.
+  # TODO(PF-156): Once WM uses RBS, we no longer need permissions to create projects.
+  app_folder_roles = [
+    "roles/resourcemanager.folderAdmin",
+    "roles/resourcemanager.projectCreator",
+    "roles/resourcemanager.projectDeleter",
+  ]
+}
+
+resource "google_service_account" "app" {
+  count = var.enable && contains(["default", "preview_shared"], var.env_type) ? 1 : 0
+
+  provider     = google.target
+  project      = var.google_project
+  account_id   = "${local.service}-${local.owner}"
+  display_name = "${local.service}-${local.owner}"
+}
+
+resource "google_billing_account_iam_member" "crl_test_admin" {
+  count              = length(google_service_account.app) > 0 ? length
+  (var.billing_account_ids) : 0
+  billing_account_id = var.billing_account_ids[count.index]
+  role               = "roles/billing.user"
+  member             = "serviceAccount:${google_service_account.app.email}"
+}
+
+resource "google_folder_iam_member" "app_folder_roles" {
+  count    = length(google_folder.workspace_project_folder) > 0 ? length(local.app_folder_roles) : 0
+  provider = google.target
+  folder   = google_folder.workspace_project_folder.id
+  role     = local.app_folder_roles[count.index]
+  member   = "serviceAccount:${google_service_account.app.email}"
+}
+
+# TODO(wchamber): Remove the cloud_trace SA in favor of the single "app" SA.
 resource "google_service_account" "cloud_trace" {
   count = var.enable && contains(["default", "preview_shared"], var.env_type) ? 1 : 0
 

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -43,7 +43,7 @@ resource "google_service_account" "app" {
 }
 
 resource "google_billing_account_iam_member" "crl_test_admin" {
-  count              = length(google_service_account.app) > 0 ? length
+  count              = var.enable && contains(["default", "preview_shared"], var.env_type) ? length
   (var.billing_account_ids) : 0
   billing_account_id = var.billing_account_ids[count.index]
   role               = "roles/billing.user"
@@ -51,7 +51,7 @@ resource "google_billing_account_iam_member" "crl_test_admin" {
 }
 
 resource "google_folder_iam_member" "app_folder_roles" {
-  count    = length(google_folder.workspace_project_folder) > 0 ? length(local.app_folder_roles) : 0
+  count    = var.enable && contains(["default", "preview_shared"], var.env_type)? length(local.app_folder_roles) : 0
   provider = google.target
   folder   = google_folder.workspace_project_folder.id
   role     = local.app_folder_roles[count.index]

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -47,14 +47,20 @@ variable "env_type" {
 }
 
 #
-# Service Account Vars
+# Service Vars
 #
-locals {
-  sa_roles = [
-    "roles/cloudsql.client"
-  ]
+variable "workspace_project_folder_id" {
+  type = string
+  description = "What google folder within which to create a folder for creating workspace google projects."
+  default = null
 }
 
+# This is mostly helpful for testing deployments. Eventually, we want users to bring their billing accounts to WM dynamically.
+variable "billing_account_ids" {
+  type = list(string)
+  description = "List of Google billing account ids to allow WSM to use for billing workspace google projects."
+  default = []
+}
 
 #
 # DNS Vars

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -50,16 +50,16 @@ variable "env_type" {
 # Service Vars
 #
 variable "workspace_project_folder_id" {
-  type = string
+  type        = string
   description = "What google folder within which to create a folder for creating workspace google projects."
-  default = null
+  default     = null
 }
 
 # This is mostly helpful for testing deployments. Eventually, we want users to bring their billing accounts to WM dynamically.
 variable "billing_account_ids" {
-  type = list(string)
+  type        = list(string)
   description = "List of Google billing account ids to allow WSM to use for billing workspace google projects."
-  default = []
+  default     = []
 }
 
 #


### PR DESCRIPTION
WM will start creating projects for workspaces. To do this it needs
- A folder to create projects within
- Permissions on the folder to create/get/delete projects
- Permissions on a billing account to set up billing for projects.
- Enabled apis for managing projects and setting up billing for projects