### PR TITLE
DDO-824 Expose rawls k8s deployment

### DIFF
--- a/rawls/README.md
+++ b/rawls/README.md
@@ -1,0 +1,41 @@
+# Terra rawls module
+
+For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)  
+and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+
+This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+`terraform-docs markdown --no-sort . > README.md`
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google.dns | n/a |
+| google.target | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| dependencies | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
+| enable | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
+| google\_project | The google project in which to create resources | `string` | n/a | yes |
+| cluster | Terra GKE cluster suffix, whatever is after terra- | `string` | n/a | yes |
+| cluster\_short | Optional short cluster name | `string` | `""` | no |
+| owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
+| dns\_zone\_name | DNS zone name | `string` | `"dsp-envs"` | no |
+| use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
+| subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
+| hostname | Service hostname | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ingress\_ip | Rawls ingress IP |
+| fqdn | Rawls fully qualified domain name |
+

--- a/rawls/dns.tf
+++ b/rawls/dns.tf
@@ -1,0 +1,21 @@
+data "google_dns_managed_zone" "dns_zone" {
+  count    = var.enable ? 1 : 0
+  provider = google.dns
+
+  name = var.dns_zone_name
+}
+
+locals {
+  fqdn = var.enable ? "${local.hostname}${local.subdomain_name}.${data.google_dns_managed_zone.dns_zone[0].dns_name}" : null
+}
+
+resource "google_dns_record_set" "ingress" {
+  count = var.enable ? 1 : 0
+
+  provider     = google.dns
+  managed_zone = data.google_dns_managed_zone.dns_zone[0].name
+  name         = local.fqdn
+  type         = "A"
+  ttl          = "300"
+  rrdatas      = [google_compute_address.ingress_ip[0].address]
+}

--- a/rawls/ip.tf
+++ b/rawls/ip.tf
@@ -1,0 +1,7 @@
+resource "google_compute_address" "ingress_ip" {
+  count = var.enable ? 1 : 0
+
+  provider = google.target
+
+  name = "terra-${var.cluster}-${local.owner}-${local.service}-ip"
+}

--- a/rawls/main.tf
+++ b/rawls/main.tf
@@ -1,0 +1,9 @@
+/**
+ * # Terra rawls module
+ * 
+ * For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
+ * and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+ *
+ * This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+ * `terraform-docs markdown --no-sort . > README.md`
+ */

--- a/rawls/outputs.tf
+++ b/rawls/outputs.tf
@@ -1,0 +1,11 @@
+#
+# IP/DNS Outputs
+#
+output "ingress_ip" {
+  value       = var.enable ? google_compute_address.ingress_ip[0].address : null
+  description = "Rawls ingress IP"
+}
+output "fqdn" {
+  value       = var.enable ? local.fqdn : null
+  description = "Rawls fully qualified domain name"
+}

--- a/rawls/provider.tf
+++ b/rawls/provider.tf
@@ -1,0 +1,7 @@
+provider "google" {
+  alias = "target"
+}
+
+provider "google" {
+  alias = "dns"
+}

--- a/rawls/variables.tf
+++ b/rawls/variables.tf
@@ -1,0 +1,66 @@
+#
+# General Vars
+#
+variable "dependencies" {
+  # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
+  type        = any
+  default     = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
+}
+variable "enable" {
+  type        = bool
+  description = "Enable flag for this module. If set to false, no resources will be created."
+  default     = true
+}
+
+variable "google_project" {
+  type        = string
+  description = "The google project in which to create resources"
+}
+variable "cluster" {
+  type        = string
+  description = "Terra GKE cluster suffix, whatever is after terra-"
+}
+variable "cluster_short" {
+  type        = string
+  description = "Optional short cluster name"
+  default     = ""
+}
+variable "owner" {
+  type        = string
+  description = "Environment or developer. Defaults to TF workspace name if left blank."
+  default     = ""
+}
+locals {
+  owner   = var.owner == "" ? terraform.workspace : var.owner
+  service = "consent-k8s" # K8s suffix is here for dns testing purposes, ot avoid overlap with GCE consent, will remove when ready to cut over
+}
+
+#
+# DNS vars
+#
+variable "dns_zone_name" {
+  type        = string
+  description = "DNS zone name"
+  default     = "dsp-envs"
+}
+variable "use_subdomain" {
+  type        = bool
+  description = "Whether to use a subdomain between the zone and hostname"
+  default     = true
+}
+variable "subdomain_name" {
+  type        = string
+  description = "Domain namespacing between zone and hostname"
+  default     = ""
+}
+variable "hostname" {
+  type        = string
+  description = "Service hostname"
+  default     = ""
+}
+locals {
+  hostname       = var.hostname == "" ? local.service : var.hostname
+  cluster_name   = var.cluster_short == "" ? var.cluster : var.cluster_short
+  subdomain_name = var.use_subdomain ? (var.subdomain_name == "" ? ".${local.owner}.${local.cluster_name}" : var.subdomain_name) : ""
+}

--- a/rawls/variables.tf
+++ b/rawls/variables.tf
@@ -33,7 +33,7 @@ variable "owner" {
 }
 locals {
   owner   = var.owner == "" ? terraform.workspace : var.owner
-  service = "consent-k8s" # K8s suffix is here for dns testing purposes, ot avoid overlap with GCE consent, will remove when ready to cut over
+  service = "rawls-k8s" # K8s suffix is here for dns testing purposes, ot avoid overlap with GCE consent, will remove when ready to cut over
 }
 
 #

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -194,7 +194,24 @@ module "rbs" {
 module "consent" {
   source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=consent-0.0.2"
 
-  enable = local.terra_apps["consent"]
+  enable = local.terra_apps["rawls"]
+
+  google_project = var.google_project
+  cluster        = var.cluster
+  cluster_short  = var.cluster_short
+
+  dns_zone_name  = var.dns_zone_name
+  subdomain_name = var.subdomain_name
+  use_subdomain  = var.use_subdomain
+
+  providers = {
+    google.target = google.target
+    google.dns    = google.dns
+  }
+}
+
+module "rawls" {
+  source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=DDO-824-expose-rawls-k8s"
 
   google_project = var.google_project
   cluster        = var.cluster

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -211,7 +211,7 @@ module "consent" {
 }
 
 module "rawls" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=DDO-824-expose-rawls-k8s"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=rawls-0.0.1"
 
   enable = local.terra_apps["rawls"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -194,7 +194,7 @@ module "rbs" {
 module "consent" {
   source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=consent-0.0.2"
 
-  enable = local.terra_apps["rawls"]
+  enable = local.terra_apps["consent"]
 
   google_project = var.google_project
   cluster        = var.cluster
@@ -212,6 +212,8 @@ module "consent" {
 
 module "rawls" {
   source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=DDO-824-expose-rawls-k8s"
+
+  enable = local.terra_apps["rawls"]
 
   google_project = var.google_project
   cluster        = var.cluster

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -211,7 +211,7 @@ module "consent" {
 }
 
 module "rawls" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=DDO-824-expose-rawls-k8s"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=DDO-824-expose-rawls-k8s"
 
   enable = local.terra_apps["rawls"]
 

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -275,3 +275,16 @@ output "consent_fqdn" {
   value       = module.consent.fqdn
   description = "fqdn for to access k8s consent deployment"
 }
+
+#
+# Rawls Outputs
+#
+output "rawls_ingress_ip" {
+  value       = module.rawls.ingress_ip
+  description = "Static ip for rawls LB"
+}
+
+output "rawls_fqdn" {
+  value       = module.rawls.fqdn
+  description = "fqdn for to access k8s rawls deployment"
+}

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -84,6 +84,7 @@ locals {
     ontology              = false,
     rbs                   = false,
     consent               = false,
+    rawls                 = false,
     },
     var.terra_apps
   )


### PR DESCRIPTION
This pr enables support for creating a static ip and dns record for k8s deployments of rawls

- initial setup to expose rawls k8s deployment
- Add support for rawls to terra-env
