### PR TITLE
PF-152 Fix workspace project folder.

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,9 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.0"
+  # TODO add & bump version.
+  #source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.0"
+  source = "../terra-workspace-manager"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,9 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.1"
+  # TODO add & bump version.
+  #source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.0"
+  source = "../terra-workspace-manager"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,9 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  # TODO add & bump version.
-  #source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.0"
-  source = "../terra-workspace-manager"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.1"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -105,6 +105,11 @@ output "workspace_cloud_trace_sa_id" {
   value       = module.workspace_manager.cloud_trace_sa_id
   description = "Workspace Manager Cloud trace Google service account ID"
 }
+output "workspace_container_folder_id" {
+  value       = module.workspace_manager.workspace_container_folder_id
+  description = "The folder id of the folder that workspace projects should be created within."
+}
+
 output "workspace_db_ip" {
   value       = module.workspace_manager.cloudsql_public_ip
   description = "Workspace Manager CloudSQL instance IP"

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -114,8 +114,8 @@ variable "use_subdomain" {
 #
 variable "wsm_workspace_project_folder_id" {
   type        = string
-  description = "What google folder within which to create a folder for creating workspace google projects."
-  default     = null
+  description = "What google folder within which to create a folder for creating workspace google projects. If empty, do not create a folder."
+  default     = ""
 }
 variable "wsm_billing_account_ids" {
   type        = list(string)

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -114,8 +114,8 @@ variable "use_subdomain" {
 #
 variable "wsm_workspace_project_folder_id" {
   type        = string
-  description = "What google folder within which to create a folder for creating workspace google projects. If empty, do not create a folder."
-  default     = ""
+  description = "What google folder within which to create a folder for creating workspace google projects."
+  default     = null
 }
 variable "wsm_billing_account_ids" {
   type        = list(string)

--- a/terra-workspace-manager/folder.tf
+++ b/terra-workspace-manager/folder.tf
@@ -2,7 +2,7 @@
 # We create a separate folder to scope the WM SA broad folder permissions to a single purpose folder.
 # TODO(PF-156): Once WM uses RBS, we no longer need permissions to create projects, or this folder.
 resource "google_folder" "workspace_project_folder" {
-  count        = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != "" ? 1 : 0
+  count        = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != null ? 1 : 0
   display_name = "${local.service}-${local.owner} workspace project folder"
   parent       = "folders/${var.workspace_project_folder_id}"
   provider     = google.target

--- a/terra-workspace-manager/folder.tf
+++ b/terra-workspace-manager/folder.tf
@@ -2,7 +2,7 @@
 # We create a separate folder to scope the WM SA broad folder permissions to a single purpose folder.
 # TODO(PF-156): Once WM uses RBS, we no longer need permissions to create projects, or this folder.
 resource "google_folder" "workspace_project_folder" {
-  count        = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != null ? 1 : 0
+  count        = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != "" ? 1 : 0
   display_name = "${local.service}-${local.owner} workspace project folder"
   parent       = "folders/${var.workspace_project_folder_id}"
   provider     = google.target

--- a/terra-workspace-manager/folder.tf
+++ b/terra-workspace-manager/folder.tf
@@ -2,9 +2,7 @@
 # We create a separate folder to scope the WM SA broad folder permissions to a single purpose folder.
 # TODO(PF-156): Once WM uses RBS, we no longer need permissions to create projects, or this folder.
 resource "google_folder" "workspace_project_folder" {
-  # Check against `null` and `"null"` since terraform passes `null` as a literal between modules.
-  # https://github.com/hashicorp/terraform/issues/21702
-  count        = var.enable && contains(["default", "preview_shared"], var.env_type) && (var.workspace_project_folder_id != null  || var.workspace_project_folder_id == "null") ? 1 : 0
+  count        = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != "" ? 1 : 0
   display_name = "${local.service}-${local.owner} workspace project folder"
   parent       = "folders/${var.workspace_project_folder_id}"
   provider     = google.target

--- a/terra-workspace-manager/folder.tf
+++ b/terra-workspace-manager/folder.tf
@@ -3,7 +3,7 @@
 # TODO(PF-156): Once WM uses RBS, we no longer need permissions to create projects, or this folder.
 resource "google_folder" "workspace_project_folder" {
   count        = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != "" ? 1 : 0
-  display_name = "${local.service}-${local.owner} workspace project folder"
+  display_name = "${local.service}-${local.owner} projects"
   parent       = "folders/${var.workspace_project_folder_id}"
   provider     = google.target
 }

--- a/terra-workspace-manager/folder.tf
+++ b/terra-workspace-manager/folder.tf
@@ -2,7 +2,9 @@
 # We create a separate folder to scope the WM SA broad folder permissions to a single purpose folder.
 # TODO(PF-156): Once WM uses RBS, we no longer need permissions to create projects, or this folder.
 resource "google_folder" "workspace_project_folder" {
-  count        = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != null ? 1 : 0
+  # Check against `null` and `"null"` since terraform passes `null` as a literal between modules.
+  # https://github.com/hashicorp/terraform/issues/21702
+  count        = var.enable && contains(["default", "preview_shared"], var.env_type) && (var.workspace_project_folder_id != null  || var.workspace_project_folder_id == "null") ? 1 : 0
   display_name = "${local.service}-${local.owner} workspace project folder"
   parent       = "folders/${var.workspace_project_folder_id}"
   provider     = google.target

--- a/terra-workspace-manager/outputs.tf
+++ b/terra-workspace-manager/outputs.tf
@@ -18,7 +18,7 @@ output "cloud_trace_sa_id" {
 # Infrastructure Outputs
 #
 output "workspace_container_folder_id" {
-  value       = if (google_folder.workspace_project_folder != null) ? google_folder.workspace_project_folder.id : null
+  value       =  length(google_folder.workspace_project_folder) > 0 ? google_folder.workspace_project_folder[0].id : null
   description = "The folder id of the folder that workspace projects should be created within."
 }
 

--- a/terra-workspace-manager/outputs.tf
+++ b/terra-workspace-manager/outputs.tf
@@ -15,6 +15,14 @@ output "cloud_trace_sa_id" {
 }
 
 #
+# Infrastructure Outputs
+#
+output "workspace_container_folder_id" {
+  value       = google_folder.workspace_project_folder.id
+  description = "The folder id of the folder that workspace projects should be created within."
+}
+
+#
 # IP/DNS Outputs
 #
 output "ingress_ip" {

--- a/terra-workspace-manager/outputs.tf
+++ b/terra-workspace-manager/outputs.tf
@@ -18,7 +18,7 @@ output "cloud_trace_sa_id" {
 # Infrastructure Outputs
 #
 output "workspace_container_folder_id" {
-  value       = google_folder.workspace_project_folder.id
+  value       = if (google_folder.workspace_project_folder != null) ? google_folder.workspace_project_folder.id : null
   description = "The folder id of the folder that workspace projects should be created within."
 }
 

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -50,7 +50,7 @@ resource "google_project_iam_member" "app" {
   member   = "serviceAccount:${google_service_account.app[0].email}"
 }
 resource "google_folder_iam_member" "app" {
-  count    = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != null ? length(local.app_folder_roles) : 0
+  count    = length(google_folder.workspace_project_folder) > 0 ? length(local.app_folder_roles) : 0
   provider = google.target
   folder   = google_folder.workspace_project_folder[0].id
   role     = local.app_folder_roles[count.index]

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -50,7 +50,7 @@ resource "google_project_iam_member" "app" {
   member   = "serviceAccount:${google_service_account.app[0].email}"
 }
 resource "google_folder_iam_member" "app" {
-  count    = length(google_folder.workspace_project_folder) > 0 ? length(local.app_folder_roles) : 0
+  count    = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != null ? length(local.app_folder_roles) : 0
   provider = google.target
   folder   = google_folder.workspace_project_folder[0].id
   role     = local.app_folder_roles[count.index]

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -51,8 +51,10 @@ variable "env_type" {
 #
 variable "workspace_project_folder_id" {
   type        = string
-  description = "What google folder within which to create a folder for creating workspace google projects."
-  default     = null
+  description = "What google folder within which to create a folder for creating workspace google projects. If empty, do not create a folder."
+  # Use empty string as a default value as TF has problems with null as a default between modules.
+  # https://github.com/hashicorp/terraform/issues/21702
+  default     = ""
 }
 
 # This is mostly helpful for testing deployments. Eventually, we want users to bring their billing accounts to WM dynamically.

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -51,10 +51,8 @@ variable "env_type" {
 #
 variable "workspace_project_folder_id" {
   type        = string
-  description = "What google folder within which to create a folder for creating workspace google projects. If empty, do not create a folder."
-  # Use empty string as a default value as TF has problems with null as a default between modules.
-  # https://github.com/hashicorp/terraform/issues/21702
-  default     = ""
+  description = "What google folder within which to create a folder for creating workspace google projects."
+  default     = null
 }
 
 # This is mostly helpful for testing deployments. Eventually, we want users to bring their billing accounts to WM dynamically.


### PR DESCRIPTION
Fix google_folder creation for workspace manager. TF does not handle null propagation correctly.
Add folder id output output is important for configuring WM helm downstream.
This should have been a part of https://github.com/broadinstitute/terraform-ap-modules/pull/90