### PR TITLE
PF-152 Fix folder count

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,8 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "../terra-workspace-manager"
-  #source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.1"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.2"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,8 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.1"
+  source = "../terra-workspace-manager"
+  #source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.1"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-workspace-manager/folder.tf
+++ b/terra-workspace-manager/folder.tf
@@ -1,8 +1,11 @@
+locals {
+  create_folder = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != ""
+}
 # Folder used to contain projects created by WM.
 # We create a separate folder to scope the WM SA broad folder permissions to a single purpose folder.
 # TODO(PF-156): Once WM uses RBS, we no longer need permissions to create projects, or this folder.
 resource "google_folder" "workspace_project_folder" {
-  count        = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != "" ? 1 : 0
+  count        = local.create_folder ? 1 : 0
   display_name = "${local.service}-${local.owner} projects"
   parent       = "folders/${var.workspace_project_folder_id}"
   provider     = google.target

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -50,7 +50,7 @@ resource "google_project_iam_member" "app" {
   member   = "serviceAccount:${google_service_account.app[0].email}"
 }
 resource "google_folder_iam_member" "app" {
-  count    = length(google_folder.workspace_project_folder) > 0 ? length(local.app_folder_roles) : 0
+  count    = local.create_folder ? length(local.app_folder_roles) : 0
   provider = google.target
   folder   = google_folder.workspace_project_folder[0].id
   role     = local.app_folder_roles[count.index]


### PR DESCRIPTION
Terraform does not like relying on the count of a resource for determining a count of another resource. While this doesn't seem to be an issue right now in `terraform-ap-deployments`, it is causing failures in some dev experimentation with preview environments, so we're proactively fixing.

```
Error: Invalid count argument

  on .terraform/modules/env.workspace_manager/terra-workspace-manager/sa.tf line 53, in resource "google_folder_iam_member" "app":
  53:   count    = length(google_folder.workspace_project_folder) > 0 ? length(local.app_folder_roles) : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```