### PR TITLE
AS-548: upgrade WSM postgres default version from 9.6 to 12 [risk: low]

### DIFF
--- a/terra-env/README.md
+++ b/terra-env/README.md
@@ -35,7 +35,7 @@ No provider.
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
 | wsm\_workspace\_project\_folder\_id | What google folder within which to create a folder for creating workspace google projects. | `string` | `null` | no |
 | wsm\_billing\_account\_ids | List of Google billing account ids to allow WM to use for billing workspace google projects. | `list(string)` | `[]` | no |
-| wsm\_db\_version | The version for the WSM CloudSQL instance | `string` | `"POSTGRES_9_6"` | no |
+| wsm\_db\_version | The version for the WSM CloudSQL instance | `string` | `"POSTGRES_12"` | no |
 | wsm\_db\_keepers | Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility | `bool` | `false` | no |
 | datarepo\_dns\_name | DNS record name, excluding zone top-level domain. Eg. data.alpha | `string` | `""` | no |
 | grafana\_dns\_name | DNS record name, excluding zone top-level domain. Eg. data.alpha | `string` | `""` | no |

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=da_AS458_upgradePostgres"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.3"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -88,6 +88,7 @@ module "workspace_manager" {
 
   db_version = var.wsm_db_version
   db_keepers = var.wsm_db_keepers
+  db_deletion_protection = false # REMOVE THIS BEFORE MERGING, CHELSEA
 
   workspace_project_folder_id = var.wsm_workspace_project_folder_id
   billing_account_ids         = var.wsm_billing_account_ids

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.5.0"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=da_AS458_upgradePostgres"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.2"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.5.0"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -88,7 +88,6 @@ module "workspace_manager" {
 
   db_version = var.wsm_db_version
   db_keepers = var.wsm_db_keepers
-  db_deletion_protection = false # REMOVE THIS BEFORE MERGING, CHELSEA
 
   workspace_project_folder_id = var.wsm_workspace_project_folder_id
   billing_account_ids         = var.wsm_billing_account_ids

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -124,7 +124,7 @@ variable "wsm_billing_account_ids" {
 }
 variable "wsm_db_version" {
   type        = string
-  default     = "POSTGRES_9_6"
+  default     = "POSTGRES_12"
   description = "The version for the WSM CloudSQL instance"
 }
 variable "wsm_db_keepers" {

--- a/terra-workspace-manager/README.md
+++ b/terra-workspace-manager/README.md
@@ -40,7 +40,7 @@ No requirements.
 | use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
 | subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
 | hostname | Service hostname | `string` | `""` | no |
-| db\_version | The version for the CloudSQL instance | `string` | `"POSTGRES_9_6"` | no |
+| db\_version | The version for the CloudSQL instance | `string` | `"POSTGRES_12"` | no |
 | db\_keepers | Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility | `bool` | `false` | no |
 | db\_tier | The default tier (DB instance size) for the CloudSQL instance | `string` | `"db-g1-small"` | no |
 | db\_name | Postgres db name | `string` | `""` | no |

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -8,7 +8,7 @@ module "cloudsql" {
   }
   project          = var.google_project
   cloudsql_name    = "${local.service}-db-${local.owner}"
-  cloudsql_version = "POSTGRES_9_6" # var.db_version
+  cloudsql_version = var.db_version
   cloudsql_keepers = var.db_keepers
   cloudsql_instance_labels = {
     "env" = local.owner

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -9,7 +9,7 @@ module "cloudsql" {
   project          = var.google_project
   cloudsql_name    = "${local.service}-db-${local.owner}"
   cloudsql_version = var.db_version
-  cloudsql_keepers = true # var.db_keepers
+  cloudsql_keepers = var.db_keepers
   cloudsql_instance_labels = {
     "env" = local.owner
     "app" = local.service

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -1,5 +1,5 @@
 module "cloudsql" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.2.1"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=ch-deletion-protection"
 
   enable = var.enable && contains(["default"], var.env_type)
 
@@ -15,6 +15,8 @@ module "cloudsql" {
     "app" = local.service
   }
   cloudsql_tier = var.db_tier
+
+  cloudsql_deletion_protection = var.db_deletion_protection
 
   app_dbs = {
     "${local.service}" = {

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -1,5 +1,5 @@
 module "cloudsql" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=ch-deletion-protection"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.2.1"
 
   enable = var.enable && contains(["default"], var.env_type)
 
@@ -15,8 +15,6 @@ module "cloudsql" {
     "app" = local.service
   }
   cloudsql_tier = var.db_tier
-
-  cloudsql_deletion_protection = var.db_deletion_protection
 
   app_dbs = {
     "${local.service}" = {

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -9,7 +9,7 @@ module "cloudsql" {
   project          = var.google_project
   cloudsql_name    = "${local.service}-db-${local.owner}"
   cloudsql_version = var.db_version
-  cloudsql_keepers = true #var.db_keepers
+  cloudsql_keepers = var.db_keepers
   cloudsql_instance_labels = {
     "env" = local.owner
     "app" = local.service

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -9,7 +9,7 @@ module "cloudsql" {
   project          = var.google_project
   cloudsql_name    = "${local.service}-db-${local.owner}"
   cloudsql_version = var.db_version
-  cloudsql_keepers = var.db_keepers
+  cloudsql_keepers = true # var.db_keepers
   cloudsql_instance_labels = {
     "env" = local.owner
     "app" = local.service

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -8,7 +8,7 @@ module "cloudsql" {
   }
   project          = var.google_project
   cloudsql_name    = "${local.service}-db-${local.owner}"
-  cloudsql_version = var.db_version
+  cloudsql_version = "POSTGRES_9_6" # var.db_version
   cloudsql_keepers = var.db_keepers
   cloudsql_instance_labels = {
     "env" = local.owner

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -9,7 +9,7 @@ module "cloudsql" {
   project          = var.google_project
   cloudsql_name    = "${local.service}-db-${local.owner}"
   cloudsql_version = var.db_version
-  cloudsql_keepers = var.db_keepers
+  cloudsql_keepers = true #var.db_keepers
   cloudsql_instance_labels = {
     "env" = local.owner
     "app" = local.service

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -99,7 +99,7 @@ locals {
 #
 variable "db_version" {
   type        = string
-  default     = "POSTGRES_9_6"
+  default     = "POSTGRES_12"
   description = "The version for the CloudSQL instance"
 }
 variable "db_keepers" {

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -122,11 +122,6 @@ variable "db_user" {
   description = "Postgres username"
   default     = ""
 }
-variable "db_deletion_protection" {
-  type        = bool
-  description = "Deletion protection. DON'T TOUCH THIS UNLESS YOU WANT TO DELETE THE DATABASE!"
-  default     = true # set to false to make it possible to delete the database
-}
 variable "stairway_db_name" {
   type        = string
   description = "Stairway db name"

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -104,8 +104,8 @@ variable "db_version" {
 }
 variable "db_keepers" {
   type        = bool
-  default     = false
-  description = "Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility"
+  default     = true
+  description = "Whether to use keepers to re-generate instance name."
 }
 variable "db_tier" {
   type        = string

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -54,7 +54,7 @@ variable "workspace_project_folder_id" {
   description = "What google folder within which to create a folder for creating workspace google projects. If empty, do not create a folder."
   # Use empty string as a default value as TF has problems with null as a default between modules.
   # https://github.com/hashicorp/terraform/issues/21702
-  default     = ""
+  default = ""
 }
 
 # This is mostly helpful for testing deployments. Eventually, we want users to bring their billing accounts to WM dynamically.
@@ -121,6 +121,11 @@ variable "db_user" {
   type        = string
   description = "Postgres username"
   default     = ""
+}
+variable "db_deletion_protection" {
+  type        = bool
+  description = "Deletion protection. DON'T TOUCH THIS UNLESS YOU WANT TO DELETE THE DATABASE!"
+  default     = true # set to false to make it possible to delete the database
 }
 variable "stairway_db_name" {
   type        = string


### PR DESCRIPTION
for review only, DO NOT MERGE (we need to give warnings before redeploying databases, don't want to merge before all warnings are given).

This upgrades Postgres CloudSQL versions for workspace manager from 9.6 to 12.