### PR TITLE
DDO-832 terra-cluster: Add taints to non-default node pools

### DIFF
--- a/terra-cluster/k8s-pools.tf
+++ b/terra-cluster/k8s-pools.tf
@@ -13,7 +13,7 @@ locals {
 module "k8s-node-pool-default-v2" {
   # boilerplate
   enable = var.node_pool_default_v2.enable
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=ch-node-pool-taints"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.3-tf-0.12"
   dependencies = [
     module.k8s-master
   ]
@@ -37,7 +37,7 @@ module "k8s-node-pool-default-v2" {
 module "k8s-node-pool-cronjob-v1" {
   # boilerplate
   enable = var.node_pool_cronjob_v1.enable
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=ch-node-pool-taints"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.3-tf-0.12"
   dependencies = [
     module.k8s-master
   ]
@@ -62,7 +62,7 @@ module "k8s-node-pool-cronjob-v1" {
 module "k8s-node-pool-cromwell-v1" {
   # boilerplate
   enable = var.node_pool_cromwell_v1.enable
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=ch-node-pool-taints"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.3-tf-0.12"
   dependencies = [
     module.k8s-master
   ]
@@ -87,7 +87,7 @@ module "k8s-node-pool-cromwell-v1" {
 module "k8s-node-pool" {
   # boilerplate
   enable = var.node_pool_default.enable
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.2-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.3-tf-0.12"
   dependencies = [
     module.k8s-master
   ]
@@ -108,7 +108,7 @@ module "k8s-node-pool" {
 module "k8s-node-pool-highmem" {
   # boilerplate
   enable = var.node_pool_highmem.enable
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.2-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.3-tf-0.12"
   dependencies = [
     module.k8s-master
   ]

--- a/terra-cluster/k8s-pools.tf
+++ b/terra-cluster/k8s-pools.tf
@@ -55,7 +55,7 @@ module "k8s-node-pool-cronjob-v1" {
   disk_size_gb = 200
   labels       = { "bio.terra/node-pool" = "cronjob" }
   tags         = setunion(local.default_node_tags, ["k8s-${module.k8s-master.name}-node-cronjob-v1"])
-  taints       = [{ key = "bio.terra/workload", value = "cronjob", effect = "NoSchedule" }]
+  taints       = [{ key = "bio.terra/workload", value = "cronjob", effect = "NO_SCHEDULE" }]
 }
 
 # cromwell-v1 node pool
@@ -80,7 +80,7 @@ module "k8s-node-pool-cromwell-v1" {
   disk_size_gb = 200
   labels       = { "bio.terra/node-pool" = "cromwell" }
   tags         = setunion(local.default_node_tags, ["k8s-${module.k8s-master.name}-node-cromwell-v1"])
-  taints       = [{ key = "bio.terra/workload", value = "cromwell", effect = "NoSchedule" }]
+  taints       = [{ key = "bio.terra/workload", value = "cromwell", effect = "NO_SCHEDULE" }]
 }
 
 # old default node pool - deprecated, will be succeeded by default-v2

--- a/terra-cluster/k8s-pools.tf
+++ b/terra-cluster/k8s-pools.tf
@@ -13,7 +13,7 @@ locals {
 module "k8s-node-pool-default-v2" {
   # boilerplate
   enable = var.node_pool_default_v2.enable
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.2-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=ch-node-pool-taints"
   dependencies = [
     module.k8s-master
   ]
@@ -55,7 +55,7 @@ module "k8s-node-pool-cronjob-v1" {
   disk_size_gb = 200
   labels       = { "bio.terra/node-pool" = "cronjob" }
   tags         = setunion(local.default_node_tags, ["k8s-${module.k8s-master.name}-node-cronjob-v1"])
-  taints       = [{ key = "workload", value = "cronjob", effect = "NoSchedule" }]
+  taints       = [{ key = "bio.terra/workload", value = "cronjob", effect = "NoSchedule" }]
 }
 
 # cromwell-v1 node pool
@@ -80,7 +80,7 @@ module "k8s-node-pool-cromwell-v1" {
   disk_size_gb = 200
   labels       = { "bio.terra/node-pool" = "cromwell" }
   tags         = setunion(local.default_node_tags, ["k8s-${module.k8s-master.name}-node-cromwell-v1"])
-  taints       = [{ key = "workload", value = "cromwell", effect = "NoSchedule" }]
+  taints       = [{ key = "bio.terra/workload", value = "cromwell", effect = "NoSchedule" }]
 }
 
 # old default node pool - deprecated, will be succeeded by default-v2

--- a/terra-cluster/k8s-pools.tf
+++ b/terra-cluster/k8s-pools.tf
@@ -55,6 +55,7 @@ module "k8s-node-pool-cronjob-v1" {
   disk_size_gb = 200
   labels       = { "bio.terra/node-pool" = "cronjob" }
   tags         = setunion(local.default_node_tags, ["k8s-${module.k8s-master.name}-node-cronjob-v1"])
+  taints       = [{ key = "workload", value = "cronjob", effect = "NoSchedule" }]
 }
 
 # cromwell-v1 node pool
@@ -79,6 +80,7 @@ module "k8s-node-pool-cromwell-v1" {
   disk_size_gb = 200
   labels       = { "bio.terra/node-pool" = "cromwell" }
   tags         = setunion(local.default_node_tags, ["k8s-${module.k8s-master.name}-node-cromwell-v1"])
+  taints       = [{ key = "workload", value = "cromwell", effect = "NoSchedule" }]
 }
 
 # old default node pool - deprecated, will be succeeded by default-v2

--- a/terra-cluster/k8s-pools.tf
+++ b/terra-cluster/k8s-pools.tf
@@ -37,7 +37,7 @@ module "k8s-node-pool-default-v2" {
 module "k8s-node-pool-cronjob-v1" {
   # boilerplate
   enable = var.node_pool_cronjob_v1.enable
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.2-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=ch-node-pool-taints"
   dependencies = [
     module.k8s-master
   ]
@@ -61,7 +61,7 @@ module "k8s-node-pool-cronjob-v1" {
 module "k8s-node-pool-cromwell-v1" {
   # boilerplate
   enable = var.node_pool_cromwell_v1.enable
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=k8s-node-pool-0.2.2-tf-0.12"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/k8s-node-pool?ref=ch-node-pool-taints"
   dependencies = [
     module.k8s-master
   ]


### PR DESCRIPTION
Specify taints on the non-default pools, to prevent random pods from being scheduled on them.

Related: https://github.com/broadinstitute/terraform-ap-deployments/pull/140