### PR TITLE
DDO-824 Rawls GKE ingress

### DIFF
--- a/rawls/dns.tf
+++ b/rawls/dns.tf
@@ -17,5 +17,5 @@ resource "google_dns_record_set" "ingress" {
   name         = local.fqdn
   type         = "A"
   ttl          = "300"
-  rrdatas      = [google_compute_address.ingress_ip[0].address]
+  rrdatas      = [google_compute_global_address.ingress_ip[0].address]
 }

--- a/rawls/ip.tf
+++ b/rawls/ip.tf
@@ -1,4 +1,4 @@
-resource "google_compute_address" "ingress_ip" {
+resource "google_compute_global_address" "ingress_ip" {
   count = var.enable ? 1 : 0
 
   provider = google.target

--- a/rawls/outputs.tf
+++ b/rawls/outputs.tf
@@ -2,7 +2,7 @@
 # IP/DNS Outputs
 #
 output "ingress_ip" {
-  value       = var.enable ? google_compute_address.ingress_ip[0].address : null
+  value       = var.enable ? google_compute_global_address.ingress_ip[0].address : null
   description = "Rawls ingress IP"
 }
 output "fqdn" {

--- a/rawls/variables.tf
+++ b/rawls/variables.tf
@@ -33,7 +33,7 @@ variable "owner" {
 }
 locals {
   owner   = var.owner == "" ? terraform.workspace : var.owner
-  service = "rawls-k8s" # K8s suffix is here for dns testing purposes, ot avoid overlap with GCE consent, will remove when ready to cut over
+  service = "consent-k8s" # K8s suffix is here for dns testing purposes, ot avoid overlap with GCE consent, will remove when ready to cut over
 }
 
 #

--- a/rawls/variables.tf
+++ b/rawls/variables.tf
@@ -33,7 +33,7 @@ variable "owner" {
 }
 locals {
   owner   = var.owner == "" ? terraform.workspace : var.owner
-  service = "consent-k8s" # K8s suffix is here for dns testing purposes, ot avoid overlap with GCE consent, will remove when ready to cut over
+  service = "rawls-k8s" # K8s suffix is here for dns testing purposes, ot avoid overlap with GCE consent, will remove when ready to cut over
 }
 
 #

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -195,7 +195,24 @@ module "rbs" {
 module "consent" {
   source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=consent-0.0.2"
 
-  enable = local.terra_apps["consent"]
+  enable = local.terra_apps["rawls"]
+
+  google_project = var.google_project
+  cluster        = var.cluster
+  cluster_short  = var.cluster_short
+
+  dns_zone_name  = var.dns_zone_name
+  subdomain_name = var.subdomain_name
+  use_subdomain  = var.use_subdomain
+
+  providers = {
+    google.target = google.target
+    google.dns    = google.dns
+  }
+}
+
+module "rawls" {
+  source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=DDO-824-expose-rawls-k8s"
 
   google_project = var.google_project
   cluster        = var.cluster

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -212,7 +212,7 @@ module "consent" {
 }
 
 module "rawls" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=DDO-824-expose-rawls-k8s"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=DDO-824-expose-rawls-k8s"
 
   enable = local.terra_apps["rawls"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -212,7 +212,7 @@ module "consent" {
 }
 
 module "rawls" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=DDO-824-expose-rawls-k8s"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=rawls-0.0.1"
 
   enable = local.terra_apps["rawls"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -212,25 +212,6 @@ module "consent" {
 }
 
 module "rawls" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=rawls-0.0.1"
-
-  enable = local.terra_apps["rawls"]
-
-  google_project = var.google_project
-  cluster        = var.cluster
-  cluster_short  = var.cluster_short
-
-  dns_zone_name  = var.dns_zone_name
-  subdomain_name = var.subdomain_name
-  use_subdomain  = var.use_subdomain
-
-  providers = {
-    google.target = google.target
-    google.dns    = google.dns
-  }
-}
-
-module "rawls" {
   source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=DDO-824-expose-rawls-k8s"
 
   enable = local.terra_apps["rawls"]

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -195,7 +195,7 @@ module "rbs" {
 module "consent" {
   source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=consent-0.0.2"
 
-  enable = local.terra_apps["rawls"]
+  enable = local.terra_apps["consent"]
 
   google_project = var.google_project
   cluster        = var.cluster
@@ -213,6 +213,8 @@ module "consent" {
 
 module "rawls" {
   source = "github.com/broadinstitute/terraform-ap-modules.git//consent?ref=DDO-824-expose-rawls-k8s"
+
+  enable = local.terra_apps["rawls"]
 
   google_project = var.google_project
   cluster        = var.cluster

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -212,7 +212,7 @@ module "consent" {
 }
 
 module "rawls" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=DDO-824-expose-rawls-k8s"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=rawls-0.0.2"
 
   enable = local.terra_apps["rawls"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -231,7 +231,7 @@ module "rawls" {
 }
 
 module "rawls" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=rawls-0.0.1"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=DDO-824-expose-rawls-k8s"
 
   enable = local.terra_apps["rawls"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -212,7 +212,7 @@ module "consent" {
 }
 
 module "rawls" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=rawls-0.0.2"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//rawls?ref=rawls-0.1.0"
 
   enable = local.terra_apps["rawls"]
 


### PR DESCRIPTION
Switching rawls to use a global static ip which is required for GKE ingress

﻿- initial setup to expose rawls k8s deployment
- Add support for rawls to terra-env
- remove copy paste error
- fix enable flags
- update source path
- update ref to release tag
-  use global static ip for GKE ingress
- switch to working branch
