### PR TITLE
DDO-943 Duos ingress ip/DNS

### DIFF
--- a/duos/README.md
+++ b/duos/README.md
@@ -1,0 +1,41 @@
+# Terra duos-ui module
+
+For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)  
+and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+
+This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+`terraform-docs markdown --no-sort . > README.md`
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google.dns | n/a |
+| google.target | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| dependencies | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
+| enable | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
+| google\_project | The google project in which to create resources | `string` | n/a | yes |
+| cluster | Terra GKE cluster suffix, whatever is after terra- | `string` | n/a | yes |
+| cluster\_short | Optional short cluster name | `string` | `""` | no |
+| owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
+| dns\_zone\_name | DNS zone name | `string` | `"dsp-envs"` | no |
+| use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
+| subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
+| hostname | Service hostname | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ingress\_ip | DUOS ingress IP |
+| fqdn | DUOS fully qualified domain name |
+

--- a/duos/dns.tf
+++ b/duos/dns.tf
@@ -1,8 +1,8 @@
 data "google_dns_managed_zone" "dns_zone" {
   count    = var.enable ? 1 : 0
   provider = google.dns
-
-  name = var.dns_zone_name
+  project  = var.google_project
+  name     = var.dns_zone_name
 }
 
 locals {
@@ -10,8 +10,8 @@ locals {
 }
 
 resource "google_dns_record_set" "ingress" {
-  count = var.enable ? 1 : 0
-
+  count        = var.enable ? 1 : 0
+  project      = var.google_project
   provider     = google.dns
   managed_zone = data.google_dns_managed_zone.dns_zone[0].name
   name         = local.fqdn

--- a/duos/dns.tf
+++ b/duos/dns.tf
@@ -1,0 +1,21 @@
+data "google_dns_managed_zone" "dns_zone" {
+  count    = var.enable ? 1 : 0
+  provider = google.dns
+
+  name = var.dns_zone_name
+}
+
+locals {
+  fqdn = var.enable ? "${local.hostname}${local.subdomain_name}.${data.google_dns_managed_zone.dns_zone[0].dns_name}" : null
+}
+
+resource "google_dns_record_set" "ingress" {
+  count = var.enable ? 1 : 0
+
+  provider     = google.dns
+  managed_zone = data.google_dns_managed_zone.dns_zone[0].name
+  name         = local.fqdn
+  type         = "A"
+  ttl          = "300"
+  rrdatas      = [google_compute_global_address.ingress_ip[0].address]
+}

--- a/duos/ip.tf
+++ b/duos/ip.tf
@@ -1,0 +1,7 @@
+resource "google_compute_global_address" "ingress_ip" {
+  count = var.enable ? 1 : 0
+
+  provider = google.target
+
+  name = "terra-${var.cluster}-${local.owner}-${local.service}-ip"
+}

--- a/duos/ip.tf
+++ b/duos/ip.tf
@@ -2,6 +2,8 @@ resource "google_compute_global_address" "ingress_ip" {
   count = var.enable ? 1 : 0
 
   provider = google.target
+  project  = var.google_project
 
   name = "terra-${var.cluster}-${local.owner}-${local.service}-ip"
 }
+

--- a/duos/main.tf
+++ b/duos/main.tf
@@ -1,0 +1,9 @@
+/**
+ * # Terra duos-ui module
+ * 
+ * For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
+ * and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+ *
+ * This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+ * `terraform-docs markdown --no-sort . > README.md`
+ */

--- a/duos/outputs.tf
+++ b/duos/outputs.tf
@@ -1,0 +1,11 @@
+#
+# IP/DNS Outputs
+#
+output "ingress_ip" {
+  value       = var.enable ? google_compute_global_address.ingress_ip[0].address : null
+  description = "DUOS ingress IP"
+}
+output "fqdn" {
+  value       = var.enable ? local.fqdn : null
+  description = "DUOS fully qualified domain name"
+}

--- a/duos/provider.tf
+++ b/duos/provider.tf
@@ -1,0 +1,7 @@
+provider "google" {
+  alias = "target"
+}
+
+provider "google" {
+  alias = "dns"
+}

--- a/duos/variables.tf
+++ b/duos/variables.tf
@@ -1,0 +1,66 @@
+#
+# General Vars
+#
+variable "dependencies" {
+  # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
+  type        = any
+  default     = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
+}
+variable "enable" {
+  type        = bool
+  description = "Enable flag for this module. If set to false, no resources will be created."
+  default     = true
+}
+
+variable "google_project" {
+  type        = string
+  description = "The google project in which to create resources"
+}
+variable "cluster" {
+  type        = string
+  description = "Terra GKE cluster suffix, whatever is after terra-"
+}
+variable "cluster_short" {
+  type        = string
+  description = "Optional short cluster name"
+  default     = ""
+}
+variable "owner" {
+  type        = string
+  description = "Environment or developer. Defaults to TF workspace name if left blank."
+  default     = ""
+}
+locals {
+  owner   = var.owner == "" ? terraform.workspace : var.owner
+  service = "duos-k8s" # K8s suffix is here for dns testing purposes, will remove when ready to cut over
+}
+
+#
+# DNS vars
+#
+variable "dns_zone_name" {
+  type        = string
+  description = "DNS zone name"
+  default     = "dsp-envs"
+}
+variable "use_subdomain" {
+  type        = bool
+  description = "Whether to use a subdomain between the zone and hostname"
+  default     = true
+}
+variable "subdomain_name" {
+  type        = string
+  description = "Domain namespacing between zone and hostname"
+  default     = ""
+}
+variable "hostname" {
+  type        = string
+  description = "Service hostname"
+  default     = ""
+}
+locals {
+  hostname       = var.hostname == "" ? local.service : var.hostname
+  cluster_name   = var.cluster_short == "" ? var.cluster : var.cluster_short
+  subdomain_name = var.use_subdomain ? (var.subdomain_name == "" ? ".${local.owner}.${local.cluster_name}" : var.subdomain_name) : ""
+}


### PR DESCRIPTION
Creating a DUOS module independent of terra-env. This will only be used to create an ip for the dev k8s 
of DUOS UI
﻿
