### PR TITLE
[PF-156] Grant WSM folder owner permissions 

### DIFF
--- a/terra-workspace-manager/folder.tf
+++ b/terra-workspace-manager/folder.tf
@@ -3,7 +3,6 @@ locals {
 }
 # Folder used to contain projects created by WM.
 # We create a separate folder to scope the WM SA broad folder permissions to a single purpose folder.
-# TODO(PF-156): Once WM uses Resource Buffer Service, we no longer need permissions to create projects, or this folder.
 resource "google_folder" "workspace_project_folder" {
   count        = local.create_folder ? 1 : 0
   display_name = "${local.service}-${local.owner} projects"

--- a/terra-workspace-manager/folder.tf
+++ b/terra-workspace-manager/folder.tf
@@ -1,8 +1,8 @@
 locals {
   create_folder = var.enable && contains(["default", "preview_shared"], var.env_type) && var.workspace_project_folder_id != ""
 }
-# Folder used to contain projects created by WM.
-# We create a separate folder to scope the WM SA broad folder permissions to a single purpose folder.
+# Folder used to contain projects created by Buffer Service, then we tell Buffer Service to use this folder to create
+# project within.
 resource "google_folder" "workspace_project_folder" {
   count        = local.create_folder ? 1 : 0
   display_name = "${local.service}-${local.owner} projects"

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -27,9 +27,7 @@ locals {
   # Roles used to manage created workspace projects.
   # TODO(PF-156): Once WM uses Resource Buffer Service, we no longer need permissions to create projects.
   app_folder_roles = [
-    "roles/resourcemanager.folderAdmin",
-    "roles/resourcemanager.projectCreator",
-    "roles/resourcemanager.projectDeleter",
+    "roles/owner",
   ]
 }
 

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -24,8 +24,8 @@ locals {
     "roles/cloudtrace.agent",
   ]
 
-  # Roles used to manage created workspace projects.
-  # TODO(PF-156): Once WM uses Resource Buffer Service, we no longer need permissions to create projects.
+  # Buffer service creates projects in this folder. Workspace Manager needs to be the  owner of the folder to have
+  # owner permission on projects inside.
   app_folder_roles = [
     "roles/owner",
   ]


### PR DESCRIPTION
With RBS integration, projects is created in RBS now, and WSM will lose project owner permission. So we need to add it here. 