### PR TITLE
[PF-197] Remove cloud trace service account from terraform

### DIFF
--- a/buffer/README.md
+++ b/buffer/README.md
@@ -18,8 +18,8 @@ No requirements.
 | Name | Version |
 |------|---------|
 | google.dns | n/a |
-| google | n/a |
 | google.target | n/a |
+| google | n/a |
 
 ## Inputs
 

--- a/crl-janitor/README.md
+++ b/crl-janitor/README.md
@@ -18,8 +18,8 @@ No requirements.
 | Name | Version |
 |------|---------|
 | google.dns | n/a |
-| google | n/a |
 | google.target | n/a |
+| google | n/a |
 
 ## Inputs
 

--- a/crl-test/README.md
+++ b/crl-test/README.md
@@ -17,8 +17,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| google.target | n/a |
 | google | n/a |
+| google.target | n/a |
 
 ## Inputs
 

--- a/single-cell-portal/README.md
+++ b/single-cell-portal/README.md
@@ -18,10 +18,10 @@ No requirements.
 | Name | Version |
 |------|---------|
 | google.dns | n/a |
-| random | n/a |
-| google.target | n/a |
 | google-beta.target | n/a |
 | http | n/a |
+| random | n/a |
+| google.target | n/a |
 
 ## Inputs
 

--- a/terra-env/README.md
+++ b/terra-env/README.md
@@ -82,7 +82,6 @@ No provider.
 | sam\_fqdn | Sam fully qualified domain name |
 | workspace\_sqlproxy\_sa\_id | Workspace Manager Cloud SQL Proxy Google service account ID |
 | workspace\_app\_sa\_id | Workspace Manager App Google service account ID |
-| workspace\_cloud\_trace\_sa\_id | Workspace Manager Cloud trace Google service account ID |
 | workspace\_container\_folder\_id | The folder id of the folder that workspace projects should be created within. |
 | workspace\_db\_ip | Workspace Manager CloudSQL instance IP |
 | workspace\_db\_instance | Workspace Manager CloudSQL instance name |

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=zl-pf197"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.5.0"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.4.4"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=zl-pf197"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -101,10 +101,6 @@ output "workspace_app_sa_id" {
   value       = module.workspace_manager.app_sa_id
   description = "Workspace Manager App Google service account ID"
 }
-output "workspace_cloud_trace_sa_id" {
-  value       = module.workspace_manager.cloud_trace_sa_id
-  description = "Workspace Manager Cloud trace Google service account ID"
-}
 output "workspace_container_folder_id" {
   value       = module.workspace_manager.workspace_container_folder_id
   description = "The folder id of the folder that workspace projects should be created within."

--- a/terra-workspace-manager/README.md
+++ b/terra-workspace-manager/README.md
@@ -54,7 +54,6 @@ No requirements.
 |------|-------------|
 | sqlproxy\_sa\_id | Workspace Manager Cloud SQL Proxy Google service account ID |
 | app\_sa\_id | Workspace Manager App Google service account ID |
-| cloud\_trace\_sa\_id | Workspace Manager Cloud trace Google service account ID |
 | workspace\_container\_folder\_id | The folder id of the folder that workspace projects should be created within. |
 | ingress\_ip | Workspace Manager ingress IP |
 | ingress\_ip\_name | Sam ingress IP name |

--- a/terra-workspace-manager/README.md
+++ b/terra-workspace-manager/README.md
@@ -20,8 +20,8 @@ No requirements.
 | Name | Version |
 |------|---------|
 | google.dns | n/a |
-| google | n/a |
 | google.target | n/a |
+| google | n/a |
 
 ## Inputs
 

--- a/terra-workspace-manager/outputs.tf
+++ b/terra-workspace-manager/outputs.tf
@@ -9,10 +9,6 @@ output "app_sa_id" {
   value       = length(google_service_account.app) > 0 ? google_service_account.app[0].account_id : null
   description = "Workspace Manager App Google service account ID"
 }
-output "cloud_trace_sa_id" {
-  value       = length(google_service_account.cloud_trace) > 0 ? google_service_account.cloud_trace[0].account_id : null
-  description = "Workspace Manager Cloud trace Google service account ID"
-}
 
 #
 # Infrastructure Outputs

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -62,22 +62,3 @@ resource "google_billing_account_iam_member" "app" {
   role               = "roles/billing.user"
   member             = "serviceAccount:${google_service_account.app[0].email}"
 }
-
-# TODO(wchamber): Remove the cloud_trace SA in favor of the single "app" SA.
-resource "google_service_account" "cloud_trace" {
-  count = var.enable && contains(["default", "preview_shared"], var.env_type) ? 1 : 0
-
-  provider     = google.target
-  project      = var.google_project
-  account_id   = "${local.service}-${local.owner}-cloud-trace"
-  display_name = "${local.service}-${local.owner}-cloud-trace"
-}
-
-resource "google_project_iam_member" "cloud_trace" {
-  count = var.enable && contains(["default", "preview_shared"], var.env_type) ? 1 : 0
-
-  provider = google.target
-  project  = var.google_project
-  role     = "roles/cloudtrace.admin"
-  member   = "serviceAccount:${google_service_account.cloud_trace[0].email}"
-}


### PR DESCRIPTION
This change removes Workspace Manager's dedicated cloud trace service account from Terraform. We've fully migrated off of it and [removed all references from WM's helm chart](https://github.com/broadinstitute/terra-helm/pull/240). As of today's release, all environments are now using updated helm charts with this change applied, so it should be safe to remove the SA from terraform config.