### PR TITLE
[PF-367] Add more permissions for WSM Service Account

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=tn-PF-367"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.6.1"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.6.0"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=tn-PF-367"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -30,6 +30,8 @@ locals {
     "roles/resourcemanager.folderAdmin",
     "roles/resourcemanager.projectCreator",
     "roles/resourcemanager.projectDeleter",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/billing.projectManager"
   ]
 
   folder_ids_and_roles = [


### PR DESCRIPTION
The new permissions are required to enable services and set billing accounts on the projects created by Buffer Service