### PR TITLE
[No-ticket] Re-add projectCreator permission for WM SA

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.6.2"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=zl-wmfix"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=zl-wmfix"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.6.3"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -28,7 +28,8 @@ locals {
   # TODO(PF-156): Once WM uses Resource Buffer Service, we no longer need permissions to create projects.
   app_folder_roles = [
     "roles/resourcemanager.folderAdmin",
-    "roles/owner"
+    "roles/owner",
+    "roles/resourcemanager.projectCreator"
   ]
 
   folder_ids_and_roles = [


### PR DESCRIPTION
Re-adds a role that was removed in #137, as we discovered that the `roles/owner` role does not include the `resourcemanager.projects.create` permission necessary for WM. This breaks workspace manager's tests.

This should be cleaned up once workspace manager is better integrated with RBS.