### PR TITLE
DDO-1017 Persistent Disk snapshot schedule

### DIFF
--- a/terra-project/README.md
+++ b/terra-project/README.md
@@ -1,0 +1,34 @@
+# terra-project module
+
+This module manages non application specific resources that are applied at the project level for a terra environment.  
+This module should only be used for non-application specific and non-k8s specific resources.
+
+For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)  
+and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+
+This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+`terraform-docs markdown --no-sort . > README.md`
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google.target | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| google\_project | google project in which to create resources | `string` | n/a | yes |
+| environment | the terra environment associated with a google project | `string` | n/a | yes |
+| snapshot\_start\_time | Time at which daily disk snapshots are taken | `string` | `"01:00"` | no |
+| snapshot\_retention\_days | Number of days to keep a snapshot, defaults to 30 for compliance | `number` | `30` | no |
+
+## Outputs
+
+No output.
+

--- a/terra-project/main.tf
+++ b/terra-project/main.tf
@@ -1,0 +1,12 @@
+/**
+ * # terra-project module
+ *
+ * This module manages non application specific resources that are applied at the project level for a terra environment.
+ * This module should only be used for non-application specific and non-k8s specific resources. 
+ *
+ * For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
+ * and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+ *
+ * This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+ * `terraform-docs markdown --no-sort . > README.md`
+ */

--- a/terra-project/provider.tf
+++ b/terra-project/provider.tf
@@ -1,0 +1,3 @@
+provider "google" {
+  alias = "target"
+}

--- a/terra-project/snapshot.tf
+++ b/terra-project/snapshot.tf
@@ -1,0 +1,24 @@
+resource "google_compute_resource_policy" "snapshot_schedule" {
+  project  = var.google_project
+  provider = google.target
+
+  name   = "terra-snapshot-policy"
+  region = "us-central1"
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time    = var.snapshot_start_time
+      }
+    }
+    retention_policy {
+      max_retention_days    = var.snapshot_retention_days
+      on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
+    }
+    snapshot_properties {
+      labels = {
+        env = var.environment
+      }
+    }
+  }
+}

--- a/terra-project/variables.tf
+++ b/terra-project/variables.tf
@@ -1,0 +1,21 @@
+variable "google_project" {
+  type        = string
+  description = "google project in which to create resources"
+}
+
+variable "environment" {
+  type        = string
+  description = "the terra environment associated with a google project"
+}
+
+variable "snapshot_start_time" {
+  type        = string
+  description = "Time at which daily disk snapshots are taken"
+  default     = "01:00"
+}
+
+variable "snapshot_retention_days" {
+  type        = number
+  description = "Number of days to keep a snapshot, defaults to 30 for compliance"
+  default     = 30
+}


### PR DESCRIPTION
Adding a terra-project module for non-application specific project wide resources. Currently only contains a snapshot schedule

﻿<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
