### PR TITLE
updating to mongo 4.4.3

### DIFF
--- a/single-cell-portal/variables.tf
+++ b/single-cell-portal/variables.tf
@@ -161,7 +161,7 @@ variable "mongodb_roles" {
 }
 variable "mongodb_version" {
   type    = string
-  default = "3.6.14"
+  default = "4.4.3"
 }
 variable "mongodb_user" {
   type    = string


### PR DESCRIPTION
<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
Updating the default version of MongoDB from `3.6.14` to `4.4.3` due to [3.6 EOL](https://www.mongodb.com/support-policy) planned for April 2021.