### PR TITLE
DDO-1012 First pass at Terraform for new Cromwell configs bucket

### DIFF
--- a/cromwell/README.md
+++ b/cromwell/README.md
@@ -1,0 +1,28 @@
+# Terra Cromwell module
+
+This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+`terraform-docs markdown --no-sort . > README.md`
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | n/a |
+| google.target | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| dependencies | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
+| google\_project | The google project in which to create resources | `string` | n/a | yes |
+| owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
+
+## Outputs
+
+No output.
+

--- a/cromwell/buckets.tf
+++ b/cromwell/buckets.tf
@@ -1,0 +1,30 @@
+#
+# cromwell-configs-prod
+#
+locals {
+  app_sa_name = "cromwell-${local.owner}"
+}
+
+# TODO Existing Google service account is still managed by terraform-firecloud
+data "google_service_account" "app-sa" {
+  account_id = local.app_sa_name
+}
+
+# Bucket where mongodb dumps will be stored
+resource "google_storage_bucket" "configs-bucket" {
+  name     = "cromwell-configs-${local.owner}"
+  provider = google.target
+
+  project       = var.google_project
+  location      = "us-central1"
+  storage_class = "STANDARD"
+}
+
+# Give Cromwell app SA permission to write to bucket
+resource "google_storage_bucket_iam_binding" "binding" {
+  provider = google.target
+
+  bucket  = google_storage_bucket.configs-bucket.name
+  role    = ["roles/storage.objectWriter"]
+  members = [data.google_service_account.app-sa.name]
+}

--- a/cromwell/buckets.tf
+++ b/cromwell/buckets.tf
@@ -25,6 +25,6 @@ resource "google_storage_bucket_iam_binding" "binding" {
   provider = google.target
 
   bucket  = google_storage_bucket.configs-bucket.name
-  role    = ["roles/storage.objectWriter"]
+  role    = ["roles/storage.objectAdmin"]
   members = [data.google_service_account.app-sa.name]
 }

--- a/cromwell/main.tf
+++ b/cromwell/main.tf
@@ -1,0 +1,6 @@
+/**
+ * # Terra Cromwell module
+ * 
+ * This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+ * `terraform-docs markdown --no-sort . > README.md`
+ */

--- a/cromwell/provider.tf
+++ b/cromwell/provider.tf
@@ -1,0 +1,3 @@
+provider "google" {
+  alias = "target"
+}

--- a/cromwell/variables.tf
+++ b/cromwell/variables.tf
@@ -1,0 +1,23 @@
+#
+# General Vars
+#
+variable "dependencies" {
+  # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
+  type        = any
+  default     = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
+}
+
+variable "google_project" {
+  type        = string
+  description = "The google project in which to create resources"
+}
+variable "owner" {
+  type        = string
+  description = "Environment or developer. Defaults to TF workspace name if left blank."
+  default     = ""
+}
+
+locals {
+  owner = var.owner == "" ? terraform.workspace : var.owner
+}


### PR DESCRIPTION
Creates a new bucket `cromwell-configs-<ENV>`, and gives existing Cromwell SA `storage.objectAdmin` on objects in the bucket.