### PR TITLE
DDO-970 Create GCS bucket for Elasticsearch snapshots

### DIFF
--- a/elasticsearch/backup.tf
+++ b/elasticsearch/backup.tf
@@ -35,7 +35,7 @@ resource "google_storage_bucket" "es-snapshot-bucket" {
 # Grant sa permission to write to bucket
 resource "google_storage_bucket_iam_binding" "es-sa-binding" {
   bucket   = google_storage_bucket.es-snapshot-bucket.name
-  provider = googel.target
+  provider = google.target
   role     = "roles/storage.objectCreator"
   members  = ["serviceAccount:${google_service_account.elasticsearch-snapshot.email}"]
 }

--- a/elasticsearch/backup.tf
+++ b/elasticsearch/backup.tf
@@ -2,6 +2,7 @@
 
 resource "google_service_account" "elasticsearch-snapshot" {
   provider     = google.target
+  project      = var.google_project
   account_id   = "elasticsearch-snapshot-${local.owner}"
   display_name = "elasticsearch-snapshot-${local.owner}"
 }
@@ -13,6 +14,7 @@ locals {
 resource "google_storage_bucket" "es-snapshot-bucket" {
   name          = "elasticsearch-backups-dsp-terra-${local.owner}"
   provider      = google.target
+  project       = var.google_project
   location      = "US"
   storage_class = "NEARLINE"
 
@@ -34,6 +36,7 @@ resource "google_storage_bucket" "es-snapshot-bucket" {
 
 # Grant sa permission to write to bucket
 resource "google_storage_bucket_iam_binding" "es-sa-binding" {
+  project  = var.google_project
   bucket   = google_storage_bucket.es-snapshot-bucket.name
   provider = google.target
   role     = "roles/storage.objectCreator"

--- a/elasticsearch/backup.tf
+++ b/elasticsearch/backup.tf
@@ -36,7 +36,6 @@ resource "google_storage_bucket" "es-snapshot-bucket" {
 
 # Grant sa permission to write to bucket
 resource "google_storage_bucket_iam_binding" "es-sa-binding" {
-  project  = var.google_project
   bucket   = google_storage_bucket.es-snapshot-bucket.name
   provider = google.target
   role     = "roles/storage.objectCreator"

--- a/elasticsearch/backup.tf
+++ b/elasticsearch/backup.tf
@@ -1,0 +1,41 @@
+# Resources to enable saving Elastic search snapshots in a gcs bucket for backup restore
+
+resource "google_service_account" "elasticsearch-snapshot" {
+  provider     = google.target
+  account_id   = "elasticsearch-snapshot-${local.owner}"
+  display_name = "elasticsearch-snapshot-${local.owner}"
+}
+
+locals {
+  seconds_per_day = 24 * 60 * 60
+}
+
+resource "google_storage_bucket" "es-snapshot-bucket" {
+  name          = "elasticsearch-backups-dsp-terra-${local.owner}"
+  provider      = google.target
+  location      = "US"
+  storage_class = "NEARLINE"
+
+  # Retain for 30 days
+  retention_policy {
+    retention_period = 30 * local.seconds_per_day
+  }
+
+  # Delete after 1 year
+  lifecycle_rule {
+    condition {
+      age = 365
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}
+
+# Grant sa permission to write to bucket
+resource "google_storage_bucket_iam_binding" "es-sa-binding" {
+  bucket   = google_storage_bucket.es-snapshot-bucket.name
+  provider = googel.target
+  role     = "roles/storage.objectCreator"
+  members  = ["serviceAccount:${google_service_account.elasticsearch-snapshot.email}"]
+}

--- a/elasticsearch/outputs.tf
+++ b/elasticsearch/outputs.tf
@@ -9,3 +9,8 @@ output "fqdn" {
   value       = local.fqdn
   description = "elasticsearch fully qualified domain name"
 }
+
+output "snapshot_sa_id" {
+  value       = google_service_account.elasticsearch-snapshot.account_id
+  description = "Elasticsearch Snapshot SA ID"
+}


### PR DESCRIPTION
Shamelessly copy @choover-broad's gcs resources for mongodb.

<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
