### PR TITLE
AS-607: pubsub topics, notifications, and permissions

### DIFF
--- a/deltalayer/buckets.tf
+++ b/deltalayer/buckets.tf
@@ -70,3 +70,12 @@ resource "google_storage_bucket_iam_binding" "error-bucket-sa-binding" {
   members  = ["serviceAccount:${google_service_account.sa_filemover[0].email}"]
 }
 
+# Pub/Sub notifications for object-finalize in the source bucket
+resource "google_storage_notification" "source-finalize-notification" {
+  bucket         = google_storage_bucket.source-bucket.name
+  provider       = google.target
+  payload_format = "JSON_API_V1"
+  topic          = google_pubsub_topic.source.id
+  event_types    = ["OBJECT_FINALIZE"]
+  depends_on     = [google_pubsub_topic_iam_binding.source-topic-publish]
+}

--- a/deltalayer/pubsub.tf
+++ b/deltalayer/pubsub.tf
@@ -1,0 +1,60 @@
+# Pub/Sub topics and subscriptions for Delta Layer
+
+# source topic
+resource "google_pubsub_topic" "source" {
+  provider = google.target
+  project  = var.google_project
+  name     = "deltalayer-source-topic"
+}
+
+# filemover topic
+resource "google_pubsub_topic" "filemover" {
+  provider = google.target
+  project  = var.google_project
+  name     = "deltalayer-filemover-topic"
+}
+
+# N.B. no need to create subscriptions; subscriptions are automatically created when the relevant
+# Cloud Functions are deployed.
+
+# automatic SA for this project: https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account
+data "google_storage_project_service_account" "gcs_account" {
+  provider = google.target
+  project  = var.google_project
+}
+
+# permission for automatic SA to publish to source topic
+resource "google_pubsub_topic_iam_binding" "source-topic-publish" {
+  provider = google.target
+  project  = var.google_project
+  topic    = google_pubsub_topic.source.name
+  role     = "roles/pubsub.publisher"
+  members  = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
+}
+
+# permission for streamer SA to publish to filemover topic
+resource "google_pubsub_topic_iam_binding" "filemover-topic-publish" {
+  provider = google.target
+  project  = var.google_project
+  topic    = google_pubsub_topic.filemover.name
+  role     = "roles/pubsub.publisher"
+  members  = ["serviceAccount:${google_service_account.sa_streamer[0].email}"]
+}
+
+# permission for streamer SA to subscribe to source topic
+resource "google_pubsub_topic_iam_binding" "source-topic-subscribe" {
+  provider = google.target
+  project  = var.google_project
+  topic    = google_pubsub_topic.source.name
+  role     = "roles/pubsub.subscriber"
+  members  = ["serviceAccount:${google_service_account.sa_streamer[0].email}"]
+}
+
+# permission for filemover SA to subscribe to filemover topic
+resource "google_pubsub_topic_iam_binding" "filemover-topic-subscribe" {
+  provider = google.target
+  project  = var.google_project
+  topic    = google_pubsub_topic.filemover.name
+  role     = "roles/pubsub.subscriber"
+  members  = ["serviceAccount:${google_service_account.sa_filemover[0].email}"]
+}


### PR DESCRIPTION
More Delta Layer work. This creates the necessary pubsub topics, their permissions, and the notifications from the  "source" bucket to the related pubsub topic.

Related terraform-ap-deployments PR at broadinstitute/terraform-ap-deployments#236, including the atlantis plan.


<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
