### PR TITLE
AS-607: delta layer database, plus uniform bucket ACLs

### DIFF
--- a/deltalayer/README.md
+++ b/deltalayer/README.md
@@ -36,6 +36,11 @@ No requirements.
 | bucket\_suffix | Suffix to append to each bucket's name. Defaults to 'owner' variable if blank. | `string` | `""` | no |
 | bucket\_location | Google region in which to create buckets | `string` | `"us-central1"` | no |
 | owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
+| db\_version | The version for the CloudSQL instance | `string` | `"POSTGRES_12"` | no |
+| db\_keepers | Whether to use keepers to re-generate instance name. | `bool` | `true` | no |
+| db\_tier | The default tier (DB instance size) for the CloudSQL instance | `string` | `"db-n1-standard-2"` | no |
+| db\_name | Postgres db name | `string` | `"deltalayer"` | no |
+| db\_user | Postgres username | `string` | `"deltalayer"` | no |
 
 ## Outputs
 
@@ -43,4 +48,8 @@ No requirements.
 |------|-------------|
 | sa\_streamer\_id | Streamer SA ID |
 | sa\_filemover\_id | File-mover SA ID |
+| cloudsql\_public\_ip | Delta Layer CloudSQL instance IP |
+| cloudsql\_instance\_name | Delta Layer CloudSQL instance name |
+| cloudsql\_root\_user\_password | Delta Layer database root password |
+| cloudsql\_app\_db\_creds | Delta Layer database user credentials |
 

--- a/deltalayer/README.md
+++ b/deltalayer/README.md
@@ -6,6 +6,19 @@ This module creates infrastructure resources for Delta Layer in Terra environmen
 
 No requirements.
 
+## Release Notes
+
+### 0.1.0
+* Initial release. Creates buckets, service accounts, and applies IAM to buckets.
+* Applies lifecycle rule to the "success" bucket to delete files after 120 days
+
+### 0.2.0
+* Creates pubsub topics and their IAM
+
+### 0.3.0
+* Applies uniform bucket-level access to the previously-created buckets
+* Creates Postgres database and proxy
+
 ## Providers
 
 | Name | Version |

--- a/deltalayer/README.md
+++ b/deltalayer/README.md
@@ -17,7 +17,7 @@ No requirements.
 
 ### 0.3.0
 * Applies uniform bucket-level access to the previously-created buckets
-* Creates Postgres database and proxy
+* Creates Postgres database
 
 ## Providers
 

--- a/deltalayer/buckets.tf
+++ b/deltalayer/buckets.tf
@@ -6,6 +6,7 @@ resource "google_storage_bucket" "source-bucket" {
   provider = google.target
   project  = var.google_project
   location = var.bucket_location
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_binding" "success-bucket-sa-binding-sourcewriter" {
@@ -36,6 +37,7 @@ resource "google_storage_bucket" "success-bucket" {
   project       = var.google_project
   location      = var.bucket_location
   storage_class = "COLDLINE"
+  uniform_bucket_level_access = true
 
   # Delete after 120 days
   lifecycle_rule {
@@ -61,6 +63,7 @@ resource "google_storage_bucket" "error-bucket" {
   provider = google.target
   project  = var.google_project
   location = var.bucket_location
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_iam_binding" "error-bucket-sa-binding" {

--- a/deltalayer/buckets.tf
+++ b/deltalayer/buckets.tf
@@ -2,10 +2,10 @@
 
 # "Source" bucket: sourcewriter_sa_email creates/writes, sa_filemover reads and deletes, sa_streamer reads
 resource "google_storage_bucket" "source-bucket" {
-  name     = "terra-deltalayer-source-${local.bucket_suffix}"
-  provider = google.target
-  project  = var.google_project
-  location = var.bucket_location
+  name                        = "terra-deltalayer-source-${local.bucket_suffix}"
+  provider                    = google.target
+  project                     = var.google_project
+  location                    = var.bucket_location
   uniform_bucket_level_access = true
 }
 
@@ -32,11 +32,11 @@ resource "google_storage_bucket_iam_binding" "success-bucket-sa-binding-streamer
 
 # "Success" bucket: sa_filemover creates/writes, coldline, auto-deletes after 120 days
 resource "google_storage_bucket" "success-bucket" {
-  name          = "terra-deltalayer-success-${local.bucket_suffix}"
-  provider      = google.target
-  project       = var.google_project
-  location      = var.bucket_location
-  storage_class = "COLDLINE"
+  name                        = "terra-deltalayer-success-${local.bucket_suffix}"
+  provider                    = google.target
+  project                     = var.google_project
+  location                    = var.bucket_location
+  storage_class               = "COLDLINE"
   uniform_bucket_level_access = true
 
   # Delete after 120 days
@@ -59,10 +59,10 @@ resource "google_storage_bucket_iam_binding" "success-bucket-sa-binding" {
 
 # "Error" bucket: sa_filemover creates/writes
 resource "google_storage_bucket" "error-bucket" {
-  name     = "terra-deltalayer-error-${local.bucket_suffix}"
-  provider = google.target
-  project  = var.google_project
-  location = var.bucket_location
+  name                        = "terra-deltalayer-error-${local.bucket_suffix}"
+  provider                    = google.target
+  project                     = var.google_project
+  location                    = var.bucket_location
   uniform_bucket_level_access = true
 }
 

--- a/deltalayer/cloudsql.tf
+++ b/deltalayer/cloudsql.tf
@@ -28,7 +28,9 @@ module "cloudsql" {
   dependencies = [var.dependencies]
 }
 
-# permission for streamer SA to use cloudsql
+# permission for streamer SA to use cloudsql. N.B. we do not create a separate sqlproxy SA, since
+# Cloud Functions are the only sql client as of this writing. In the future, if we move to standalone
+# services accessing this SQL instance, we may want to create a new sqlproxy SA.
 resource "google_project_iam_member" "cloudsql" {
   provider = google.target
   project  = var.google_project

--- a/deltalayer/cloudsql.tf
+++ b/deltalayer/cloudsql.tf
@@ -1,0 +1,37 @@
+module "cloudsql" {
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.2.1"
+
+  count = var.enable ? 1 : 0
+
+  providers = {
+    google.target = google.target
+  }
+  project          = var.google_project
+  cloudsql_name    = "${local.service}-db-${local.owner}"
+  cloudsql_version = var.db_version
+  cloudsql_keepers = var.db_keepers
+  cloudsql_instance_labels = {
+    "env" = local.owner
+    "app" = local.service
+  }
+  cloudsql_tier = var.db_tier
+
+  cloudsql_replication_type = null
+
+  app_dbs = {
+    "${local.service}" = {
+      db       = local.db_name
+      username = local.db_user
+    }
+  }
+
+  dependencies = [var.dependencies]
+}
+
+# permission for streamer SA to use cloudsql
+resource "google_project_iam_member" "cloudsql" {
+  provider = google.target
+  project  = var.google_project
+  role     = "roles/cloudsql.client"
+  member   = "serviceAccount:${google_service_account.sa_streamer[0].email}"
+}

--- a/deltalayer/outputs.tf
+++ b/deltalayer/outputs.tf
@@ -11,3 +11,26 @@ output "sa_filemover_id" {
   value       = google_service_account.sa_filemover[0].account_id
   description = "File-mover SA ID"
 }
+
+#
+# CloudSQL PostgreSQL Outputs
+#
+output "cloudsql_public_ip" {
+  value       = var.enable ? module.cloudsql.public_ip : null
+  description = "Delta Layer CloudSQL instance IP"
+}
+output "cloudsql_instance_name" {
+  value       = var.enable ? module.cloudsql.instance_name : null
+  description = "Delta Layer CloudSQL instance name"
+}
+output "cloudsql_root_user_password" {
+  value       = var.enable ? module.cloudsql.root_user_password : null
+  description = "Delta Layer database root password"
+  sensitive   = true
+}
+output "cloudsql_app_db_creds" {
+  # Avoiding error on destroy with below condition
+  value       = var.enable ? (length(module.cloudsql.app_db_creds) == 0 ? {} : module.cloudsql.app_db_creds[local.service]) : null
+  description = "Delta Layer database user credentials"
+  sensitive   = true
+}

--- a/deltalayer/outputs.tf
+++ b/deltalayer/outputs.tf
@@ -16,21 +16,21 @@ output "sa_filemover_id" {
 # CloudSQL PostgreSQL Outputs
 #
 output "cloudsql_public_ip" {
-  value       = var.enable ? module.cloudsql.public_ip : null
+  value       = var.enable ? module.cloudsql[0].public_ip : null
   description = "Delta Layer CloudSQL instance IP"
 }
 output "cloudsql_instance_name" {
-  value       = var.enable ? module.cloudsql.instance_name : null
+  value       = var.enable ? module.cloudsql[0].instance_name : null
   description = "Delta Layer CloudSQL instance name"
 }
 output "cloudsql_root_user_password" {
-  value       = var.enable ? module.cloudsql.root_user_password : null
+  value       = var.enable ? module.cloudsql[0].root_user_password : null
   description = "Delta Layer database root password"
   sensitive   = true
 }
 output "cloudsql_app_db_creds" {
   # Avoiding error on destroy with below condition
-  value       = var.enable ? (length(module.cloudsql.app_db_creds) == 0 ? {} : module.cloudsql.app_db_creds[local.service]) : null
+  value       = var.enable ? (length(module.cloudsql[0].app_db_creds) == 0 ? {} : module.cloudsql[0].app_db_creds[local.service]) : null
   description = "Delta Layer database user credentials"
   sensitive   = true
 }

--- a/deltalayer/variables.tf
+++ b/deltalayer/variables.tf
@@ -62,7 +62,7 @@ variable "db_keepers" {
 }
 variable "db_tier" {
   type        = string
-  default     = "db-n1-standard-2" #relatively small; resize when/if needed
+  default     = "db-custom-4-8192" #relatively small; resize when/if needed
   description = "The default tier (DB instance size) for the CloudSQL instance"
 }
 variable "db_name" {

--- a/deltalayer/variables.tf
+++ b/deltalayer/variables.tf
@@ -26,13 +26,13 @@ variable "sourcewriter_sa_email" {
 variable "bucket_suffix" {
   type        = string
   description = "Suffix to append to each bucket's name. Defaults to 'owner' variable if blank."
-  default = ""
+  default     = ""
 }
 
 variable "bucket_location" {
   type        = string
   description = "Google region in which to create buckets"
-  default = "us-central1"
+  default     = "us-central1"
 }
 
 variable "owner" {
@@ -42,9 +42,9 @@ variable "owner" {
 }
 
 locals {
-  owner           = var.owner == "" ? terraform.workspace : var.owner
-  bucket_suffix   = var.bucket_suffix == "" ? local.owner : var.bucket_suffix
-  service         = "deltalayer"
+  owner         = var.owner == "" ? terraform.workspace : var.owner
+  bucket_suffix = var.bucket_suffix == "" ? local.owner : var.bucket_suffix
+  service       = "deltalayer"
 }
 
 #
@@ -76,6 +76,6 @@ variable "db_user" {
   default     = ""
 }
 locals {
-  db_name     = var.db_name == "" ? local.service : var.db_name
-  db_user     = var.db_user == "" ? local.service : var.db_user
+  db_name = var.db_name == "" ? local.service : var.db_name
+  db_user = var.db_user == "" ? local.service : var.db_user
 }

--- a/deltalayer/variables.tf
+++ b/deltalayer/variables.tf
@@ -47,3 +47,35 @@ locals {
   service         = "deltalayer"
 }
 
+#
+# Postgres CloudSQL DB Vars
+#
+variable "db_version" {
+  type        = string
+  default     = "POSTGRES_12"
+  description = "The version for the CloudSQL instance"
+}
+variable "db_keepers" {
+  type        = bool
+  default     = true
+  description = "Whether to use keepers to re-generate instance name."
+}
+variable "db_tier" {
+  type        = string
+  default     = "db-n1-standard-2" #relatively small; resize when/if needed
+  description = "The default tier (DB instance size) for the CloudSQL instance"
+}
+variable "db_name" {
+  type        = string
+  description = "Postgres db name"
+  default     = ""
+}
+variable "db_user" {
+  type        = string
+  description = "Postgres username"
+  default     = ""
+}
+locals {
+  db_name     = var.db_name == "" ? local.service : var.db_name
+  db_user     = var.db_user == "" ? local.service : var.db_user
+}


### PR DESCRIPTION
This should be the final set of PRs for Delta Layer for a while. Changes in this one:
* Applies uniform bucket-level access to the previously-created buckets
* Creates Postgres database

Corresponding terraform-ap-deployments PR, including plan: broadinstitute/terraform-ap-deployments#238

<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
