### PR TITLE
DDO-1088 mongo: global compute addresses do not work on lb services

### DIFF
--- a/mongodb/ip.tf
+++ b/mongodb/ip.tf
@@ -1,4 +1,4 @@
-resource "google_compute_global_address" "ingress_ip" {
+resource "google_compute_address" "ingress_ip" {
   count = var.expose ? var.replica_count : 0
 
   provider = google.target


### PR DESCRIPTION
Fix MongoDB terraform -- global compute addresses do not work on lb services