### PR TITLE
DDO-1125 Expose elasticsearch for local development

### DIFF
--- a/elasticsearch/ip.tf
+++ b/elasticsearch/ip.tf
@@ -5,3 +5,10 @@ resource "google_compute_address" "ingress_ip" {
   name = "terra-${var.cluster}-${local.owner}-${local.service}-ip"
 }
 
+resource "google_compute_address" "expose_ips" {
+  count    = var.expose ? var.replica_count : 0
+  provider = google.target
+  project  = var.google_project
+
+  name = "terra-${var.cluster}-${local.owner}-${local.service}-ip-${count.index}"
+}

--- a/elasticsearch/variables.tf
+++ b/elasticsearch/variables.tf
@@ -52,3 +52,16 @@ locals {
   cluster_name   = var.cluster_short == "" ? var.cluster : var.cluster_short
   subdomain_name = var.use_subdomain ? (var.subdomain_name == "" ? ".${local.owner}.${local.cluster_name}" : var.subdomain_name) : ""
 }
+
+# Exposing elasticsearch for local development
+variable "expose" {
+  type        = bool
+  description = "If true, create an ip for each ES pod"
+  default     = false
+}
+
+variable "replica_count" {
+  type        = number
+  description = "Number of ips to create"
+  default     = 3
+}


### PR DESCRIPTION
Shamelessly copying @choover-broad's expose pattern from mongo to enable local development to still use dev elasticsearch after k8s cutover


﻿<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
