### PR TITLE
DDO-1107 workspace manager: Make it possible to run two CloudSQL instances side-by-side, to facilitate upgrades

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=ch-DDO-1107"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.6.4"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.6.3"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=ch-DDO-1107"
 
   enable = local.terra_apps["workspace_manager"]
 
@@ -89,8 +89,8 @@ module "workspace_manager" {
   db_version = var.wsm_db_version
   db_keepers = var.wsm_db_keepers
 
-  workspace_project_folder_id = var.wsm_workspace_project_folder_id
-  billing_account_ids         = var.wsm_billing_account_ids
+  workspace_project_folder_id  = var.wsm_workspace_project_folder_id
+  billing_account_ids          = var.wsm_billing_account_ids
   workspace_project_folder_ids = local.wsm_folder_ids
 
   providers = {
@@ -188,8 +188,8 @@ module "buffer" {
   db_keepers = var.buffer_db_keepers
 
   external_folder_ids = var.buffer_external_folder_ids
-  root_folder_id = var.buffer_root_folder_id
-  pool_names = var.buffer_pool_names
+  root_folder_id      = var.buffer_root_folder_id
+  pool_names          = var.buffer_pool_names
 
   billing_account_ids = var.buffer_billing_account_ids
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -86,8 +86,7 @@ module "workspace_manager" {
   subdomain_name = var.subdomain_name
   use_subdomain  = var.use_subdomain
 
-  db_version = var.wsm_db_version
-  db_keepers = var.wsm_db_keepers
+  cloudsql_pg12_settings = var.wsm_cloudsql_pg12_settings
 
   workspace_project_folder_id  = var.wsm_workspace_project_folder_id
   billing_account_ids          = var.wsm_billing_account_ids

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -105,28 +105,9 @@ output "workspace_container_folder_id" {
   value       = module.workspace_manager.workspace_container_folder_id
   description = "The folder id of the folder that workspace projects should be created within."
 }
-output "workspace_db_ip" {
-  value       = module.workspace_manager.cloudsql_public_ip
-  description = "Workspace Manager CloudSQL instance IP"
-}
-output "workspace_db_instance" {
-  value       = module.workspace_manager.cloudsql_instance_name
-  description = "Workspace Manager CloudSQL instance name"
-}
-output "workspace_db_root_pass" {
-  value       = module.workspace_manager.cloudsql_root_user_password
-  description = "Workspace Manager database root password"
-  sensitive   = true
-}
-output "workspace_db_creds" {
-  value       = module.workspace_manager.cloudsql_app_db_creds
-  description = "Workspace Manager database user credentials"
-  sensitive   = true
-}
-output "workspace_stairway_db_creds" {
-  value       = module.workspace_manager.cloudsql_app_stairway_db_creds
-  description = "Stairway database user credentials"
-  sensitive   = true
+output "workspace_db_pg12" {
+  value       = module.workspace_manager.cloudsql_pg12_outputs
+  description = "Workspace Manager CloudSQL Postgres 12 Database outputs"
 }
 output "workspace_ingress_ip" {
   value       = module.workspace_manager.ingress_ip
@@ -325,7 +306,7 @@ output "leonardo_fqdn" {
 
 #
 # Firecloud Orchestration Outputs
-# 
+#
 
 output "firecloudorch_ingress_ip" {
   value       = module.firecloudorch.ingress_ip

--- a/terra-env/outputs.tf
+++ b/terra-env/outputs.tf
@@ -105,9 +105,9 @@ output "workspace_container_folder_id" {
   value       = module.workspace_manager.workspace_container_folder_id
   description = "The folder id of the folder that workspace projects should be created within."
 }
-output "workspace_db_pg12" {
+output "workspace_cloudsql_pg12_outputs" {
   value       = module.workspace_manager.cloudsql_pg12_outputs
-  description = "Workspace Manager CloudSQL Postgres 12 Database outputs"
+  description = "Workspace Manager CloudSQL Postgres 12 instance outputs"
 }
 output "workspace_ingress_ip" {
   value       = module.workspace_manager.ingress_ip

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -126,16 +126,6 @@ variable "wsm_billing_account_ids" {
   description = "List of Google billing account ids to allow WM to use for billing workspace google projects."
   default     = []
 }
-variable "wsm_db_version" {
-  type        = string
-  default     = "POSTGRES_12"
-  description = "The version for the WSM CloudSQL instance"
-}
-variable "wsm_db_keepers" {
-  type        = bool
-  default     = false
-  description = "Whether to use keepers to re-generate instance name. Disabled by default for backwards-compatibility"
-}
 variable "wsm_buffer_pool_names" {
   type        = list(string)
   description = "Names of the buffer service pools that create projects for WSM."
@@ -151,7 +141,7 @@ variable "wsm_external_folder_ids" {
 }
 
 locals {
- wsm_folder_ids = concat(var.wsm_external_folder_ids, [for p in var.wsm_buffer_pool_names: module.buffer.pool_name_to_folder_id[p]])
+  wsm_folder_ids = concat(var.wsm_external_folder_ids, [for p in var.wsm_buffer_pool_names : module.buffer.pool_name_to_folder_id[p]])
 }
 #
 # Prometheus / Grafana vars

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -131,6 +131,11 @@ variable "wsm_buffer_pool_names" {
   description = "Names of the buffer service pools that create projects for WSM."
   default     = []
 }
+variable "wsm_cloudsql_pg12_settings" {
+  type        = object
+  description = "Settings for the WSM CloudSQL pg12 instance"
+  default     = {}
+}
 # This field should be used in personal environments when the folder containing google projects
 # comes from the tools RBS. Otherwise, all projects should be created by Buffer Service
 # in the corresponding environment and the name of the pool should be passed in above.

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -132,7 +132,7 @@ variable "wsm_buffer_pool_names" {
   default     = []
 }
 variable "wsm_cloudsql_pg12_settings" {
-  type        = object
+  type        = map
   description = "Settings for the WSM CloudSQL pg12 instance"
   default     = {}
 }

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -1,4 +1,40 @@
+# Old CloudSQL instance -- will be deleted
 module "cloudsql" {
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.2.1"
+
+  enable = var.enable && contains(["default"], var.env_type)
+
+  providers = {
+    google.target = google.target
+  }
+  project          = var.google_project
+  cloudsql_name    = "${local.service}-db-${local.owner}"
+  cloudsql_version = "POSTGRES_12"
+  cloudsql_keepers = var.db_keepers
+  cloudsql_instance_labels = {
+    "env" = local.owner
+    "app" = local.service
+  }
+  cloudsql_tier = "db-g1-small"
+
+  cloudsql_replication_type = null
+
+  app_dbs = {
+    "${local.service}" = {
+      db       = local.db_name
+      username = local.db_user
+    }
+    "${local.service}-stairway" = {
+      db       = local.stairway_db_name
+      username = local.stairway_db_user
+    }
+  }
+
+  dependencies = [var.dependencies]
+}
+
+# New CloudSQL instance, added for Postgres 13 upgrade
+module "cloudsql-red" {
   source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.2.1"
 
   enable = var.enable && contains(["default"], var.env_type)

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -9,59 +9,24 @@ module "cloudsql" {
   }
   project          = var.google_project
   cloudsql_name    = "${local.service}-db-${local.owner}"
-  cloudsql_version = "POSTGRES_12"
-  cloudsql_keepers = var.db_keepers
+  cloudsql_version = local.cloudsql_pg12_settings.version
+  cloudsql_keepers = local.cloudsql_pg12_settings.keepers
   cloudsql_instance_labels = {
     "env" = local.owner
     "app" = local.service
   }
-  cloudsql_tier = "db-g1-small"
+  cloudsql_tier = local.cloudsql_pg12_settings.tier
 
   cloudsql_replication_type = null
 
   app_dbs = {
     "${local.service}" = {
-      db       = local.db_name
-      username = local.db_user
+      db       = local.cloudsql_pg12_settings.db_name
+      username = local.cloudsql_pg12_settings.db_user
     }
     "${local.service}-stairway" = {
-      db       = local.stairway_db_name
-      username = local.stairway_db_user
-    }
-  }
-
-  dependencies = [var.dependencies]
-}
-
-# New CloudSQL instance, added for Postgres 13 upgrade
-module "cloudsql-red" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.2.1"
-
-  enable = var.enable && contains(["default"], var.env_type)
-
-  providers = {
-    google.target = google.target
-  }
-  project          = var.google_project
-  cloudsql_name    = "${local.service}-db-${local.owner}"
-  cloudsql_version = var.db_version
-  cloudsql_keepers = var.db_keepers
-  cloudsql_instance_labels = {
-    "env" = local.owner
-    "app" = local.service
-  }
-  cloudsql_tier = var.db_tier
-
-  cloudsql_replication_type = null
-
-  app_dbs = {
-    "${local.service}" = {
-      db       = local.db_name
-      username = local.db_user
-    }
-    "${local.service}-stairway" = {
-      db       = local.stairway_db_name
-      username = local.stairway_db_user
+      db       = local.cloudsql_pg12_settings.stairway_db_name
+      username = local.cloudsql_pg12_settings.stairway_db_user
     }
   }
 

--- a/terra-workspace-manager/outputs.tf
+++ b/terra-workspace-manager/outputs.tf
@@ -14,7 +14,7 @@ output "app_sa_id" {
 # Infrastructure Outputs
 #
 output "workspace_container_folder_id" {
-  value       =  length(google_folder.workspace_project_folder) > 0 ? google_folder.workspace_project_folder[0].id : null
+  value       = length(google_folder.workspace_project_folder) > 0 ? google_folder.workspace_project_folder[0].id : null
   description = "The folder id of the folder that workspace projects should be created within."
 }
 
@@ -35,29 +35,21 @@ output "fqdn" {
 }
 
 #
-# CloudSQL PostgreSQL Outputs
+# CloudSQL Outputs
 #
-output "cloudsql_public_ip" {
-  value       = var.enable && contains(["default"], var.env_type) ? module.cloudsql.public_ip : null
-  description = "Workspace Manager CloudSQL instance IP"
-}
-output "cloudsql_instance_name" {
-  value       = var.enable && contains(["default"], var.env_type) ? module.cloudsql.instance_name : null
-  description = "Workspace Manager CloudSQL instance name"
-}
-output "cloudsql_root_user_password" {
-  value       = var.enable && contains(["default"], var.env_type) ? module.cloudsql.root_user_password : null
-  description = "Workspace Manager database root password"
-  sensitive   = true
-}
-output "cloudsql_app_db_creds" {
-  # Avoiding error on destroy with below condition
-  value       = var.enable && contains(["default"], var.env_type) ? (length(module.cloudsql.app_db_creds) == 0 ? {} : module.cloudsql.app_db_creds[local.service]) : null
-  description = "Workspace Manager database user credentials"
-  sensitive   = true
-}
-output "cloudsql_app_stairway_db_creds" {
-  value       = var.enable && contains(["default"], var.env_type) ? (length(module.cloudsql.app_db_creds) == 0 ? {} : module.cloudsql.app_db_creds["${local.service}-stairway"]) : null
-  description = "Stairway database user credentials"
-  sensitive   = true
+output "cloudsql_pg12_outputs" {
+  description = "Workspace Manager CloudSQL outputs"
+  value = {
+    # pg12 CloudSQL instance IP
+    public_ip = var.enable && contains(["default"], var.env_type) ? module.cloudsql.public_ip : null,
+    # pg12 CloudSQL instance name
+    instance_name = var.enable && contains(["default"], var.env_type) ? module.cloudsql.instance_name : null
+    # pg12 database root password
+    root_user_password = var.enable && contains(["default"], var.env_type) ? module.cloudsql.root_user_password : null
+    # pg12 app db creds
+    app_db_creds = var.enable && contains(["default"], var.env_type) ? (length(module.cloudsql.app_db_creds) == 0 ? {} : module.cloudsql.app_db_creds[local.service]) : null
+    # pg12 stairway db creds
+    stairway_db_creds = var.enable && contains(["default"], var.env_type) ? (length(module.cloudsql.app_db_creds) == 0 ? {} : module.cloudsql.app_db_creds["${local.service}-stairway"]) : null
+  }
+  sensitive = true
 }

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -105,7 +105,7 @@ locals {
 #
 variable "db_version" {
   type        = string
-  default     = "POSTGRES_12"
+  default     = "POSTGRES_13"
   description = "The version for the CloudSQL instance"
 }
 variable "db_keepers" {

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -115,7 +115,7 @@ variable "db_keepers" {
 }
 variable "db_tier" {
   type        = string
-  default     = "db-g1-small"
+  default     = "db-custom-4-8192"
   description = "The default tier (DB instance size) for the CloudSQL instance"
 }
 variable "db_name" {

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -103,44 +103,40 @@ locals {
 #
 # Postgres CloudSQL DB Vars
 #
-variable "db_version" {
-  type        = string
-  default     = "POSTGRES_13"
-  description = "The version for the CloudSQL instance"
-}
-variable "db_keepers" {
-  type        = bool
-  default     = true
-  description = "Whether to use keepers to re-generate instance name."
-}
-variable "db_tier" {
-  type        = string
-  default     = "db-custom-4-8192"
-  description = "The default tier (DB instance size) for the CloudSQL instance"
-}
-variable "db_name" {
-  type        = string
-  description = "Postgres db name"
-  default     = ""
-}
-variable "db_user" {
-  type        = string
-  description = "Postgres username"
-  default     = ""
-}
-variable "stairway_db_name" {
-  type        = string
-  description = "Stairway db name"
-  default     = ""
-}
-variable "stairway_db_user" {
-  type        = string
-  description = "Stairway db username"
-  default     = ""
-}
 locals {
-  db_name          = var.db_name == "" ? local.service : var.db_name
-  db_user          = var.db_user == "" ? local.service : var.db_user
-  stairway_db_name = var.stairway_db_name == "" ? "${local.service}-stairway" : var.stairway_db_name
-  stairway_db_user = var.stairway_db_user == "" ? "${local.service}-stairway" : var.stairway_db_user
+  cloudsql_pg12_defaults = {
+    version          = "POSTGRES_12",               # Version for CloudSQL instance
+    keepers          = true,                        # Whether to use keepers to re-generate instance name
+    tier             = "db-g1-small",               # The default tier (DB instance size) for the CloudSQL instance
+    db_name          = local.service,               # Name of app DB
+    db_user          = local.service,               # Name of app DB user
+    stairway_db_name = "${local.service}-stairway", # Name of stairway DB
+    stairway_db_user = "${local.service}-stairway", # Name of stairway DB user
+  }
+  cloudsql_pg13_defaults = {
+    version          = "POSTGRES_13",               # Version for CloudSQL instance
+    keepers          = true,                        # Whether to use keepers to re-generate instance name
+    tier             = "db-custom-4-8192",          # The default tier (DB instance size) for the CloudSQL instance
+    db_name          = local.service,               # Name of app DB
+    db_user          = local.service,               # Name of app DB user
+    stairway_db_name = "${local.service}-stairway", # Name of stairway DB
+    stairway_db_user = "${local.service}-stairway", # Name of stairway DB user
+  }
+}
+
+variable "cloudsql_pg12_settings" {
+  type        = object
+  default     = {}
+  description = "Settings for Postgres 12 CloudSQL instance"
+}
+
+variable "cloudsql_pg13_settings" {
+  type        = object
+  default     = {}
+  description = "Settings for Postgres 13 CloudSQL instance"
+}
+
+locals {
+  cloudsql_pg12_settings = merge(local.cloudsql_pg12_defaults, var.cloudsql_pg12_settings)
+  cloudsql_pg13_settings = merge(local.cloudsql_pg13_defaults, var.cloudsql_pg13_settings)
 }

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -125,13 +125,13 @@ locals {
 }
 
 variable "cloudsql_pg12_settings" {
-  type        = object
+  type        = map
   default     = {}
   description = "Settings for Postgres 12 CloudSQL instance"
 }
 
 variable "cloudsql_pg13_settings" {
-  type        = object
+  type        = map
   default     = {}
   description = "Settings for Postgres 13 CloudSQL instance"
 }


### PR DESCRIPTION
Update the terra-env and terra-workspace-manger modules to support running two CloudSQL instances side-by-side, which is necessary for upgrades.

Related:
https://github.com/broadinstitute/terraform-ap-deployments/pull/253