### PR TITLE
PF-468 Enable AI notebooks for the crl-test project and service account

### DIFF
--- a/crl-test/api-services.tf
+++ b/crl-test/api-services.tf
@@ -16,5 +16,6 @@ module "enable-services" {
     "bigquery.googleapis.com",
     "cloudbilling.googleapis.com",
     "iam.googleapis.com",
+    "notebooks.googleapis.com",
   ]
 }

--- a/crl-test/project.tf
+++ b/crl-test/project.tf
@@ -3,5 +3,5 @@ resource "google_project" "project" {
   project_id          = var.google_project
   billing_account     = var.billing_account_id
   folder_id           = var.folder_id
-  auto_create_network = false
+  auto_create_network = true
 }

--- a/crl-test/service_accounts.tf
+++ b/crl-test/service_accounts.tf
@@ -21,6 +21,7 @@ locals {
     "roles/storage.admin",
     "roles/bigquery.admin",
     "roles/notebooks.admin",
+    "roles/iam.serviceAccountUser", # Used in AI Notebooks creation.
   ]
 
   # Roles used to manage projects for integration testing.

--- a/crl-test/service_accounts.tf
+++ b/crl-test/service_accounts.tf
@@ -20,6 +20,7 @@ locals {
     # Roles used in integration testing.
     "roles/storage.admin",
     "roles/bigquery.admin",
+    "roles/notebooks.admin",
   ]
 
   # Roles used to manage projects for integration testing.


### PR DESCRIPTION
<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
