### PR TITLE
PF-625 Enable AI notebooks for the janitor test.

### DIFF
--- a/janitor-test/api-services.tf
+++ b/janitor-test/api-services.tf
@@ -10,5 +10,6 @@ module "enable-services" {
     "storage-api.googleapis.com",
     "storage-component.googleapis.com",
     "bigquery.googleapis.com",
+    "notebooks.googleapis.com",
   ]
 }

--- a/janitor-test/network.tf
+++ b/janitor-test/network.tf
@@ -2,5 +2,5 @@
 resource "google_compute_network" "vpc_network" {
   name = "network"
   auto_create_subnetworks = true
-  project = google_project.project
+  project = google_project.project.project_id
 }

--- a/janitor-test/network.tf
+++ b/janitor-test/network.tf
@@ -1,0 +1,6 @@
+# Create a VPC network for testing AI Notebooks, which require a network.
+resource "google_compute_network" "vpc_network" {
+  name = "network"
+  auto_create_subnetworks = true
+  project = google_project.project
+}

--- a/janitor-test/network.tf
+++ b/janitor-test/network.tf
@@ -1,6 +1,6 @@
 # Create a VPC network for testing AI Notebooks, which require a network.
 resource "google_compute_network" "vpc_network" {
-  name = "network"
+  name = "default"
   auto_create_subnetworks = true
   project = google_project.project.project_id
 }


### PR DESCRIPTION
Enable the AI notebooks api.
Create a 'default' vpc_network for AI notebook instances to use in testing.

Our project had the default vpc network deleted at project creation time. As we can't go back in time to undo it, instead add a "google_compute_network" resource to create a new vpc network to be used in tests.