### PR TITLE
Initial design of the Test Runner results reporting infrastructure to support Google streaming Cloud Functions.

### DIFF
--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -38,7 +38,7 @@ In Review.
 | files\_success | The path of the google storage bucket (the string after gs://). To be used by a cloud function to store successfully ingested files. | `string` | `""` | no |
 | files\_location | Google region in which to create buckets | `string` | `"us-central1"` | no |
 | cloud\_functions\_repo | The name of the Test Runner repo that is the source of cloud functions. | `string` | `"terra-test-runner"` | no |
-| bq\_dataset | The name of the BigQuery dataset for ingestion. | `string` | `"test_runner_results"` | no |
+| bq\_dataset\_id | The ID of the BigQuery dataset for ingestion. | `string` | `"test_runner_results"` | no |
 | owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
 
 

--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -1,0 +1,52 @@
+# Terra Test Runner Results Reporting module
+
+This module creates infrastructure resources for Test Runner Results Reporting in Terra environments.
+
+## Requirements
+
+No requirements.
+
+## Status
+
+In Review.
+
+### Initial Preview
+* Creates buckets, service accounts, and applies IAM to buckets.
+* Applies lifecycle rule to the "success" bucket to delete files after 120 days
+* Creates pubsub topics and their IAM
+* Create cloud functions and their IAM
+
+### TODOs
+* Creates Test Runner Kubernetes service account and associated RBAC roles / rolebindings.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google.target | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| dependencies | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
+| enable | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
+| google\_project | The google project in which to create resources | `string` | n/a | yes |
+| testrunner\_sa\_email | The email of the Test Runner service account that will be used for all test results reporting tasks | `string` | n/a | yes |
+| files\_source | The name of the google storage bucket (the string after gs://). To be used by Test Runner to temporarily store JSON files for consumption by streaming cloud function. | `string` | `""` | no |
+| files\_error | The name of the google storage bucket (the string after gs://). To be used by a cloud function to store error files. | `string` | `""` | no |
+| files\_success | The path of the google storage bucket (the string after gs://). To be used by a cloud function to store successfully ingested files. | `string` | `""` | no |
+| files\_location | Google region in which to create buckets | `string` | `"us-central1"` | no |
+| cloud\_functions\_repo | The name of the Test Runner repo that is the source of cloud functions. | `string` | `"terra-test-runner"` | no |
+| bq\_dataset | The name of the BigQuery dataset for ingestion. | `string` | `"test_runner_results"` | no |
+| owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
+
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| sa\_streamer\_id | Streamer SA ID |
+| sa\_filemover\_id | File-mover SA ID |
+
+

--- a/testrunner/buckets.tf
+++ b/testrunner/buckets.tf
@@ -1,6 +1,6 @@
 # Buckets for delta layer
 
-# "Source" bucket: testrunner_sa creates/writes, reads and deletes, sa_streamer reads
+# "Source" bucket: sa_streamer reads, sa_filemover moves.
 resource "google_storage_bucket" "source-bucket" {
   name                        = local.files_source
   provider                    = google.target
@@ -16,7 +16,7 @@ resource "google_storage_bucket_iam_binding" "testrunner-sa-binding" {
   members  = ["serviceAccount:${var.testrunner_sa_email}"]
 }
 
-# "Success" bucket: testrunner_sa creates/writes, coldline, auto-deletes after 120 days
+# "Success" bucket: sa_filemover coldline, auto-deletes after 120 days
 resource "google_storage_bucket" "success-bucket" {
   name                        = local.files_success
   provider                    = google.target
@@ -36,25 +36,20 @@ resource "google_storage_bucket" "success-bucket" {
   }
 }
 
-resource "google_storage_bucket_iam_binding" "success-bucket-sa-binding-streamer" {
-  bucket   = google_storage_bucket.source-bucket.name
-  provider = google.target
-  role     = "roles/storage.objectViewer"
-  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
-}
-
-resource "google_storage_bucket_iam_binding" "success-bucket-sa-binding-filemover" {
+# permission for sa_filemover to move files from
+resource "google_storage_bucket_iam_binding" "source-bucket-filemover" {
   bucket   = google_storage_bucket.source-bucket.name
   provider = google.target
   role     = "roles/storage.objectAdmin"
-  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+  members  = ["serviceAccount:${google_service_account.sa_filemover[0].email}"]
 }
 
-resource "google_storage_bucket_iam_binding" "success-bucket-sa-binding" {
-  bucket   = google_storage_bucket.success-bucket.name
+# permission for sa_filemover to move files to coldline
+resource "google_storage_bucket_iam_binding" "success-bucket-filemover" {
+  bucket   = google_storage_bucket.source-bucket.name
   provider = google.target
   role     = "roles/storage.objectCreator"
-  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+  members  = ["serviceAccount:${google_service_account.sa_filemover[0].email}"]
 }
 
 # "Error" bucket: sa_filemover creates/writes
@@ -66,26 +61,20 @@ resource "google_storage_bucket" "error-bucket" {
   uniform_bucket_level_access = true
 }
 
-resource "google_storage_bucket_iam_binding" "error-bucket-sa-binding-filemover" {
-  bucket   = google_storage_bucket.error-bucket.name
-  provider = google.target
-  role     = "roles/storage.objectAdmin"
-  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
-}
-
-resource "google_storage_bucket_iam_binding" "error-bucket-sa-binding" {
+# permission for sa_filemover to move files to during error handling
+resource "google_storage_bucket_iam_binding" "error-bucket-filemover" {
   bucket   = google_storage_bucket.error-bucket.name
   provider = google.target
   role     = "roles/storage.objectCreator"
-  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+  members  = ["serviceAccount:${google_service_account.sa_filemover[0].email}"]
 }
 
 # Pub/Sub notifications for object-finalize in the source bucket
 resource "google_storage_notification" "source-finalize-notification" {
   bucket         = google_storage_bucket.source-bucket.name
-  provider       = google.target
   payload_format = "JSON_API_V1"
-  topic          = google_pubsub_topic.source.id
+  provider       = google.target
+  topic          = google_pubsub_topic.source-topic.id
   event_types    = ["OBJECT_FINALIZE"]
-  depends_on     = [google_pubsub_topic_iam_binding.source-topic-publish]
+  depends_on     = [google_pubsub_topic_iam_binding.source-topic-publisher]
 }

--- a/testrunner/buckets.tf
+++ b/testrunner/buckets.tf
@@ -1,0 +1,91 @@
+# Buckets for delta layer
+
+# "Source" bucket: testrunner_sa creates/writes, reads and deletes, sa_streamer reads
+resource "google_storage_bucket" "source-bucket" {
+  name                        = local.files_source
+  provider                    = google.target
+  project                     = var.google_project
+  location                    = var.files_region
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_iam_binding" "testrunner-sa-binding" {
+  bucket   = google_storage_bucket.source-bucket.name
+  provider = google.target
+  role     = "roles/storage.objectCreator"
+  members  = ["serviceAccount:${var.testrunner_sa_email}"]
+}
+
+# "Success" bucket: testrunner_sa creates/writes, coldline, auto-deletes after 120 days
+resource "google_storage_bucket" "success-bucket" {
+  name                        = local.files_success
+  provider                    = google.target
+  project                     = var.google_project
+  location                    = var.files_region
+  storage_class               = "COLDLINE"
+  uniform_bucket_level_access = true
+
+  # Delete after 120 days
+  lifecycle_rule {
+    condition {
+      age = 120
+    }
+    action {
+      type = "Delete"
+    }
+  }
+}
+
+resource "google_storage_bucket_iam_binding" "success-bucket-sa-binding-streamer" {
+  bucket   = google_storage_bucket.source-bucket.name
+  provider = google.target
+  role     = "roles/storage.objectViewer"
+  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+}
+
+resource "google_storage_bucket_iam_binding" "success-bucket-sa-binding-filemover" {
+  bucket   = google_storage_bucket.source-bucket.name
+  provider = google.target
+  role     = "roles/storage.objectAdmin"
+  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+}
+
+resource "google_storage_bucket_iam_binding" "success-bucket-sa-binding" {
+  bucket   = google_storage_bucket.success-bucket.name
+  provider = google.target
+  role     = "roles/storage.objectCreator"
+  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+}
+
+# "Error" bucket: sa_filemover creates/writes
+resource "google_storage_bucket" "error-bucket" {
+  name                        = local.files_error
+  provider                    = google.target
+  project                     = var.google_project
+  location                    = var.files_region
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_iam_binding" "error-bucket-sa-binding-filemover" {
+  bucket   = google_storage_bucket.error-bucket.name
+  provider = google.target
+  role     = "roles/storage.objectAdmin"
+  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+}
+
+resource "google_storage_bucket_iam_binding" "error-bucket-sa-binding" {
+  bucket   = google_storage_bucket.error-bucket.name
+  provider = google.target
+  role     = "roles/storage.objectCreator"
+  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+}
+
+# Pub/Sub notifications for object-finalize in the source bucket
+resource "google_storage_notification" "source-finalize-notification" {
+  bucket         = google_storage_bucket.source-bucket.name
+  provider       = google.target
+  payload_format = "JSON_API_V1"
+  topic          = google_pubsub_topic.source.id
+  event_types    = ["OBJECT_FINALIZE"]
+  depends_on     = [google_pubsub_topic_iam_binding.source-topic-publish]
+}

--- a/testrunner/cloudfunctions.tf
+++ b/testrunner/cloudfunctions.tf
@@ -1,0 +1,38 @@
+resource "google_cloudfunctions_function" "bq" {
+  name        = "testrunner-bq-streamer"
+  description = "Cloud function for streaming test runner results from source-bucket to BigQuery"
+  runtime     = "java11"
+
+  available_memory_mb   = 128
+  source_repository = {
+    url = "https://source.developers.google.com/projects/${var.google_project}/repos/${var.cloud_functions_repo}/master/paths/src/functions/streaming"
+  }
+
+  event_trigger {
+    event_type = "google.storage.object.finalize"
+    resource = google_storage_bucket.source-bucket
+  }
+  timeout               = 60
+  # The class entry point does not exist yet.
+  entry_point           = "functions.streaming.bq"
+
+  # A set of key-value environment pairs to assign to the function.
+  # These can be used to set up custom vars to configure the cloud function
+  # for different target environments.
+  environment_variables = {
+    BQ_DATASET = "`${var.google_project}.${var.bq_dataset}`"
+  }
+
+  # Only us-central1 is supported at this time.
+  region = "us-central1"
+}
+
+# IAM entry for Test Runner SA to invoke the function
+resource "google_cloudfunctions_function_iam_member" "bq-invoker" {
+  project        = google_cloudfunctions_function.bq.project
+  region         = google_cloudfunctions_function.bq.region
+  cloud_function = google_cloudfunctions_function.bq.name
+
+  role   = "roles/cloudfunctions.invoker"
+  member = "serviceAccount:${var.testrunner_sa_email}"
+}

--- a/testrunner/cloudfunctions.tf
+++ b/testrunner/cloudfunctions.tf
@@ -1,38 +1,113 @@
-resource "google_cloudfunctions_function" "bq" {
-  name        = "testrunner-bq-streamer"
-  description = "Cloud function for streaming test runner results from source-bucket to BigQuery"
+resource "google_cloudfunctions_function" "bq-streamer" {
+  name        = "bq-streamer"
+  description = "Cloud function for streaming JSON from source-bucket to BigQuery"
   runtime     = "java11"
 
-  available_memory_mb   = 128
-  source_repository = {
-    url = "https://source.developers.google.com/projects/${var.google_project}/repos/${var.cloud_functions_repo}/master/paths/src/functions/streaming"
-  }
+  available_memory_mb   = 512
+
+  timeout               = 60
+
+  # This class entry point does not exist yet.
+  entry_point           = "functions.streaming.bq"
 
   event_trigger {
-    event_type = "google.storage.object.finalize"
     resource = google_storage_bucket.source-bucket
+    event_type = "google.storage.object.finalize"
   }
-  timeout               = 60
-  # The class entry point does not exist yet.
-  entry_point           = "functions.streaming.bq"
+
+  # The SA associated with the function at runtime.
+  service_account_email = google_service_account.sa_bq_streamer[0].email
 
   # A set of key-value environment pairs to assign to the function.
   # These can be used to set up custom vars to configure the cloud function
   # for different target environments.
   environment_variables = {
-    BQ_DATASET = "`${var.google_project}.${var.bq_dataset}`"
+    BQ_DATASET_ID = "${var.google_project}.${var.bq_dataset_id}"
+  }
+
+  source_repository = {
+    url = "https://source.developers.google.com/projects/${var.google_project}/repos/${var.cloud_functions_repo}/master/paths/src/functions/streaming"
   }
 
   # Only us-central1 is supported at this time.
   region = "us-central1"
 }
 
-# IAM entry for Test Runner SA to invoke the function
-resource "google_cloudfunctions_function_iam_member" "bq-invoker" {
-  project        = google_cloudfunctions_function.bq.project
-  region         = google_cloudfunctions_function.bq.region
-  cloud_function = google_cloudfunctions_function.bq.name
+# grant streamer SA ownership to BigQuery dataset
+resource "google_bigquery_dataset_iam_binding" "bq-streamer-rb" {
+  provider       = google.target
+  project        = var.google_project
+  dataset_id     = var.bq_dataset_id
+  role           = "roles/bigquery.dataOwner"
+  members        = ["serviceAccount:${google_service_account.sa_bq_streamer[0].email}"]
+}
 
-  role   = "roles/cloudfunctions.invoker"
-  member = "serviceAccount:${var.testrunner_sa_email}"
+resource "google_cloudfunctions_function" "streaming-error-handler" {
+  name        = "streaming-error-handler"
+  description = "Cloud function for handling streaming errors"
+  runtime     = "java11"
+
+  available_memory_mb   = 512
+
+  timeout               = 60
+
+  # This class entry point does not exist yet.
+  entry_point           = "functions.fileMover"
+
+  event_trigger {
+    resource = google_pubsub_topic.streaming_error_topic
+    event_type = "google.pubsub.topic.publish"
+  }
+
+  # The SA associated with the function at runtime.
+  service_account_email = google_service_account.sa_filemover[0].email
+
+  # A set of key-value environment pairs to assign to the function.
+  # These can be used to set up custom vars to configure the cloud function
+  # for different target environments.
+  environment_variables = {
+    DESTINATION_BUCKET = var.files_error
+  }
+
+  source_repository = {
+    url = "https://source.developers.google.com/projects/${var.google_project}/repos/${var.cloud_functions_repo}/master/paths/src/functions"
+  }
+
+  # Only us-central1 is supported at this time.
+  region = "us-central1"
+}
+
+resource "google_cloudfunctions_function" "streaming-success-handler" {
+  name        = "streaming-success-handler"
+  description = "Cloud function for handling streaming success"
+  runtime     = "java11"
+
+  available_memory_mb   = 512
+
+  timeout               = 60
+
+  # This class entry point does not exist yet.
+  entry_point           = "functions.fileMover"
+
+  event_trigger {
+    resource = google_pubsub_topic.streaming_success_topic
+    event_type = "google.pubsub.topic.publish"
+  }
+
+  # The SA associated with the function at runtime.
+  service_account_email = google_service_account.sa_filemover[0].email
+
+  # A set of key-value environment pairs to assign to the function.
+  # These can be used to set up custom vars to configure the cloud function
+  # for different target environments.
+  environment_variables = {
+    DESTINATION_BUCKET = var.files_success
+  }
+
+  source_repository = {
+    url = "https://source.developers.google.com/projects/${var.google_project}/repos/${var.cloud_functions_repo}/master/paths/src/functions"
+  }
+
+  # Only us-central1 is supported at this time.
+  region = "us-central1"
 }

--- a/testrunner/main.tf
+++ b/testrunner/main.tf
@@ -1,0 +1,6 @@
+/**
+ * # Terra Test Runner module
+ *
+ * This module creates infrastructure resources for Test Runner in Terra environments.
+ *
+ */

--- a/testrunner/outputs.tf
+++ b/testrunner/outputs.tf
@@ -2,12 +2,17 @@
 # Service account ID Outputs
 #
 
-output "sa_streamer_id" {
+output "sa_testrunner_id" {
   value       = google_service_account.sa_testrunner[0].account_id
-  description = "Streamer SA ID"
+  description = "TestRunner SA ID"
+}
+
+output "sa_bq_streamer_id" {
+  value       = google_service_account.sa_bq_streamer[0].account_id
+  description = "bq_streamer SA ID"
 }
 
 output "sa_filemover_id" {
-  value       = google_service_account.sa_testrunner[0].account_id
-  description = "File-mover SA ID"
+  value       = google_service_account.sa_filemover[0].account_id
+  description = "Filemover SA ID"
 }

--- a/testrunner/outputs.tf
+++ b/testrunner/outputs.tf
@@ -1,0 +1,13 @@
+#
+# Service account ID Outputs
+#
+
+output "sa_streamer_id" {
+  value       = google_service_account.sa_testrunner[0].account_id
+  description = "Streamer SA ID"
+}
+
+output "sa_filemover_id" {
+  value       = google_service_account.sa_testrunner[0].account_id
+  description = "File-mover SA ID"
+}

--- a/testrunner/provider.tf
+++ b/testrunner/provider.tf
@@ -1,0 +1,3 @@
+provider "google" {
+  alias = "target"
+}

--- a/testrunner/pubsub.tf
+++ b/testrunner/pubsub.tf
@@ -1,0 +1,54 @@
+# Pub/Sub topics and subscriptions for Delta Layer
+
+# source topic
+resource "google_pubsub_topic" "source" {
+  provider = google.target
+  project  = var.google_project
+  name     = "testrunner-source-topic"
+}
+
+# filemover topic
+resource "google_pubsub_topic" "filemover" {
+  provider = google.target
+  project  = var.google_project
+  name     = "testrunner-filemover-topic"
+}
+
+# N.B. no need to create subscriptions; subscriptions are automatically created when the relevant
+# Cloud Functions are deployed.
+
+# permission for TestRunner SA to publish to source topic
+resource "google_pubsub_topic_iam_binding" "source-topic-publish" {
+  provider = google.target
+  project  = var.google_project
+  topic    = google_pubsub_topic.source.name
+  role     = "roles/pubsub.publisher"
+  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+}
+
+# permission for TestRunner SA to publish to filemover topic
+resource "google_pubsub_topic_iam_binding" "filemover-topic-publish" {
+  provider = google.target
+  project  = var.google_project
+  topic    = google_pubsub_topic.filemover.name
+  role     = "roles/pubsub.publisher"
+  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+}
+
+# permission for TestRunner SA to subscribe to source topic
+resource "google_pubsub_topic_iam_binding" "source-topic-subscribe" {
+  provider = google.target
+  project  = var.google_project
+  topic    = google_pubsub_topic.source.name
+  role     = "roles/pubsub.subscriber"
+  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+}
+
+# permission for TestRunner SA to subscribe to filemover topic
+resource "google_pubsub_topic_iam_binding" "filemover-topic-subscribe" {
+  provider = google.target
+  project  = var.google_project
+  topic    = google_pubsub_topic.filemover.name
+  role     = "roles/pubsub.subscriber"
+  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+}

--- a/testrunner/pubsub.tf
+++ b/testrunner/pubsub.tf
@@ -1,54 +1,76 @@
-# Pub/Sub topics and subscriptions for Delta Layer
+# Pub/Sub topics and subscriptions for Test Runner Reporting framework
 
 # source topic
-resource "google_pubsub_topic" "source" {
+resource "google_pubsub_topic" "source-topic" {
   provider = google.target
   project  = var.google_project
-  name     = "testrunner-source-topic"
+  name     = "source-topic"
 }
 
-# filemover topic
-resource "google_pubsub_topic" "filemover" {
+# Enable notifications by giving the correct IAM permission to the unique service account.
+
+data "google_storage_project_service_account" "gcs_account" {
+  provider = google.target
+  project = var.google_project
+}
+
+resource "google_pubsub_topic_iam_binding" "source-topic-publisher" {
+  topic   = google_pubsub_topic.source-topic.id
+  role    = "roles/pubsub.publisher"
+  members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
+}
+
+# End enabling notifications
+
+# streaming error topic
+resource "google_pubsub_topic" "streaming_error_topic" {
   provider = google.target
   project  = var.google_project
-  name     = "testrunner-filemover-topic"
+  name     = "streaming-error-topic"
+}
+
+# streaming success topic
+resource "google_pubsub_topic" "streaming_success_topic" {
+  provider = google.target
+  project  = var.google_project
+  name     = "streaming-success-topic"
 }
 
 # N.B. no need to create subscriptions; subscriptions are automatically created when the relevant
 # Cloud Functions are deployed.
 
-# permission for TestRunner SA to publish to source topic
-resource "google_pubsub_topic_iam_binding" "source-topic-publish" {
+# permission for Streamer SA to publish to error topic
+resource "google_pubsub_topic_iam_binding" "streaming_error_topic_publisher" {
   provider = google.target
   project  = var.google_project
-  topic    = google_pubsub_topic.source.name
+  topic    = google_pubsub_topic.streaming_error_topic.name
   role     = "roles/pubsub.publisher"
-  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+  members  = ["serviceAccount:${google_service_account.sa_bq_streamer[0].email}"]
 }
 
-# permission for TestRunner SA to publish to filemover topic
-resource "google_pubsub_topic_iam_binding" "filemover-topic-publish" {
+# permission for Streamer SA to publish to success topic
+resource "google_pubsub_topic_iam_binding" "streaming_success_topic_publisher" {
   provider = google.target
   project  = var.google_project
-  topic    = google_pubsub_topic.filemover.name
+  topic    = google_pubsub_topic.streaming_success_topic.name
   role     = "roles/pubsub.publisher"
-  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+  members  = ["serviceAccount:${google_service_account.sa_bq_streamer[0].email}"]
 }
 
-# permission for TestRunner SA to subscribe to source topic
-resource "google_pubsub_topic_iam_binding" "source-topic-subscribe" {
+# permission for filemover SA to subscribe to error topic
+resource "google_pubsub_topic_iam_binding" "streaming_error_topic_subscriber" {
   provider = google.target
   project  = var.google_project
-  topic    = google_pubsub_topic.source.name
+  topic    = google_pubsub_topic.streaming_error_topic.name
   role     = "roles/pubsub.subscriber"
-  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+  members  = ["serviceAccount:${google_service_account.sa_filemover[0].email}"]
 }
 
-# permission for TestRunner SA to subscribe to filemover topic
-resource "google_pubsub_topic_iam_binding" "filemover-topic-subscribe" {
+# permission for filemover SA to subscribe to success topic
+resource "google_pubsub_topic_iam_binding" "streaming_success_topic_subscriber" {
   provider = google.target
   project  = var.google_project
-  topic    = google_pubsub_topic.filemover.name
+  topic    = google_pubsub_topic.streaming_success_topic.name
   role     = "roles/pubsub.subscriber"
-  members  = ["serviceAccount:${google_service_account.sa_testrunner[0].email}"]
+  members  = ["serviceAccount:${google_service_account.sa_filemover[0].email}"]
 }

--- a/testrunner/sa.tf
+++ b/testrunner/sa.tf
@@ -1,4 +1,4 @@
-# One Test Runner Service account for everything
+# One Test Runner Service account for uploading results files to a bucket
 resource "google_service_account" "sa_testrunner" {
   count = var.enable ? 1 : 0
 

--- a/testrunner/sa.tf
+++ b/testrunner/sa.tf
@@ -1,0 +1,9 @@
+# One Test Runner Service account for everything
+resource "google_service_account" "sa_testrunner" {
+  count = var.enable ? 1 : 0
+
+  provider     = google.target
+  project      = var.google_project
+  account_id   = "testrunner-sa"
+  display_name = "testrunner-sa"
+}

--- a/testrunner/sa.tf
+++ b/testrunner/sa.tf
@@ -7,3 +7,23 @@ resource "google_service_account" "sa_testrunner" {
   account_id   = "testrunner-sa"
   display_name = "testrunner-sa"
 }
+
+# Service account for the "streamer" cloud function
+resource "google_service_account" "sa_bq_streamer" {
+  count = var.enable ? 1 : 0
+
+  provider     = google.target
+  project      = var.google_project
+  account_id   = "${local.service}-${local.owner}-streamer"
+  display_name = "${local.service}-${local.owner}-streamer"
+}
+
+# Service account for the "file-mover" cloud function.
+resource "google_service_account" "sa_filemover" {
+  count = var.enable ? 1 : 0
+
+  provider     = google.target
+  project      = var.google_project
+  account_id   = "${local.service}-${local.owner}-filemover"
+  display_name = "${local.service}-${local.owner}-filemover"
+}

--- a/testrunner/variables.tf
+++ b/testrunner/variables.tf
@@ -1,0 +1,73 @@
+#
+# General Vars
+#
+variable "dependencies" {
+  # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
+  type        = any
+  default     = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
+}
+variable "enable" {
+  type        = bool
+  description = "Enable flag for this module. If set to false, no resources will be created."
+  default     = true
+}
+
+variable "google_project" {
+  type        = string
+  description = "The google project in which to create resources"
+}
+
+variable "testrunner_sa_email" {
+  type        = string
+  description = "The email of the service account that will write files to the source bucket"
+}
+
+variable "files_source" {
+  type        = string
+  description = "The name of the google storage bucket (the string after gs://). To be used by Test Runner to temporarily store JSON files for consumption by streaming cloud function."
+  default     = ""
+}
+
+variable "files_error" {
+  type        = string
+  description = "The name of the google storage bucket (the string after gs://). To be used by a cloud function to store error files."
+  default     = ""
+}
+
+variable "files_success" {
+  type        = string
+  description = "The path of the google storage bucket (the string after gs://). To be used by a cloud function to store successfully ingested files."
+  default     = ""
+}
+
+variable "files_region" {
+  type        = string
+  description = "Google region in which to create buckets"
+  default     = "us-central1"
+}
+
+variable "owner" {
+  type        = string
+  description = "Environment or developer. Defaults to TF workspace name if left blank."
+  default     = ""
+}
+
+variable "cloud_functions_repo" {
+  type        = string
+  description = "The name of the Test Runner repo that is the source of cloud functions."
+  default     = "terra-test-runner"
+}
+
+variable "bq_dataset" {
+  type        = string
+  description = "The name of the BigQuery dataset for ingestion."
+  default     = "test_runner_results"
+}
+
+locals {
+  owner          = var.owner == "" ? terraform.workspace : var.owner
+  files_source   = var.files_source == "" ? "testrunner-results" : var.files_source
+  files_error    = var.files_error == "" ? "testrunner-stream-errors" : var.files_error
+  files_success  = var.files_success == "" ? "testrunner-stream-success" : var.files_success
+}

--- a/testrunner/variables.tf
+++ b/testrunner/variables.tf
@@ -59,15 +59,16 @@ variable "cloud_functions_repo" {
   default     = "terra-test-runner"
 }
 
-variable "bq_dataset" {
+variable "bq_dataset_id" {
   type        = string
   description = "The name of the BigQuery dataset for ingestion."
   default     = "test_runner_results"
 }
 
 locals {
+  service        = "testrunner"
   owner          = var.owner == "" ? terraform.workspace : var.owner
-  files_source   = var.files_source == "" ? "testrunner-results" : var.files_source
-  files_error    = var.files_error == "" ? "testrunner-stream-errors" : var.files_error
-  files_success  = var.files_success == "" ? "testrunner-stream-success" : var.files_success
+  files_source   = var.files_source == "" ? "${local.service}-results" : var.files_source
+  files_error    = var.files_error == "" ? "${local.service}-streaming-errors" : var.files_error
+  files_success  = var.files_success == "" ? "${local.service}-streaming-success" : var.files_success
 }


### PR DESCRIPTION
**No need to merge. The spike and initial enhancement work reflected by this ticket will continue in the `deltalayer` as [QA-1456](https://broadworkbench.atlassian.net/browse/QA-1456).**

This module sets the stage for initial design review to support the use of Google streaming Cloud Functions to send Test Runner results to BigQuery.

The `README` has a summary of the various components of the module. 

A thorough review of this module is required before deployment can take place, which will be done in the `terraform-ap-deployments` repo.

Since our last perf framework checkin on May 7th, new enhancements have been added to this PR.

We now use separate SAs for different cloud resources.

<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
