### PR TITLE
[IA-2746] Add calhoun module

### DIFF
--- a/calhoun/README.md
+++ b/calhoun/README.md
@@ -1,6 +1,6 @@
 # Terra calhoun module
 
-For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)  
+For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
 and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
 
 This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
@@ -14,28 +14,39 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| google.dns | n/a |
-| google.target | n/a |
+| <a name="provider_google.dns"></a> [google.dns](#provider\_google.dns) | n/a |
+| <a name="provider_google.target"></a> [google.target](#provider\_google.target) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_global_address.ingress_ip](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_dns_record_set.ingress](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| [google_dns_managed_zone.dns_zone](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_managed_zone) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| dependencies | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
-| enable | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
-| google\_project | The google project in which to create resources | `string` | n/a | yes |
-| cluster | Terra GKE cluster suffix, whatever is after terra- | `string` | n/a | yes |
-| cluster\_short | Optional short cluster name | `string` | `""` | no |
-| owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
-| dns\_zone\_name | DNS zone name | `string` | `"dsp-envs"` | no |
-| use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
-| subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
-| hostname | Service hostname | `string` | `""` | no |
+| <a name="input_dependencies"></a> [dependencies](#input\_dependencies) | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
+| <a name="input_enable"></a> [enable](#input\_enable) | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
+| <a name="input_google_project"></a> [google\_project](#input\_google\_project) | The google project in which to create resources | `string` | n/a | yes |
+| <a name="input_cluster"></a> [cluster](#input\_cluster) | Terra GKE cluster suffix, whatever is after terra- | `string` | n/a | yes |
+| <a name="input_cluster_short"></a> [cluster\_short](#input\_cluster\_short) | Optional short cluster name | `string` | `""` | no |
+| <a name="input_owner"></a> [owner](#input\_owner) | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
+| <a name="input_dns_zone_name"></a> [dns\_zone\_name](#input\_dns\_zone\_name) | DNS zone name | `string` | `"dsp-envs"` | no |
+| <a name="input_use_subdomain"></a> [use\_subdomain](#input\_use\_subdomain) | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
+| <a name="input_subdomain_name"></a> [subdomain\_name](#input\_subdomain\_name) | Domain namespacing between zone and hostname | `string` | `""` | no |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | Service hostname | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| ingress\_ip | Calhoun ingress IP |
-| fqdn | Calhoun fully qualified domain name |
-
+| <a name="output_ingress_ip"></a> [ingress\_ip](#output\_ingress\_ip) | Calhoun ingress IP |
+| <a name="output_fqdn"></a> [fqdn](#output\_fqdn) | Calhoun fully qualified domain name |

--- a/calhoun/README.md
+++ b/calhoun/README.md
@@ -1,0 +1,41 @@
+# Terra calhoun module
+
+For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)  
+and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+
+This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+`terraform-docs markdown --no-sort . > README.md`
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google.dns | n/a |
+| google.target | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| dependencies | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
+| enable | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
+| google\_project | The google project in which to create resources | `string` | n/a | yes |
+| cluster | Terra GKE cluster suffix, whatever is after terra- | `string` | n/a | yes |
+| cluster\_short | Optional short cluster name | `string` | `""` | no |
+| owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
+| dns\_zone\_name | DNS zone name | `string` | `"dsp-envs"` | no |
+| use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
+| subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
+| hostname | Service hostname | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ingress\_ip | Calhoun ingress IP |
+| fqdn | Calhoun fully qualified domain name |
+

--- a/calhoun/dns.tf
+++ b/calhoun/dns.tf
@@ -1,0 +1,21 @@
+data "google_dns_managed_zone" "dns_zone" {
+  count    = var.enable ? 1 : 0
+  provider = google.dns
+  project  = var.google_project
+  name     = var.dns_zone_name
+}
+
+locals {
+  fqdn = var.enable ? "${local.hostname}${local.subdomain_name}.${data.google_dns_managed_zone.dns_zone[0].dns_name}" : null
+}
+
+resource "google_dns_record_set" "ingress" {
+  count        = var.enable ? 1 : 0
+  project      = var.google_project
+  provider     = google.dns
+  managed_zone = data.google_dns_managed_zone.dns_zone[0].name
+  name         = local.fqdn
+  type         = "A"
+  ttl          = "300"
+  rrdatas      = [google_compute_global_address.ingress_ip[0].address]
+}

--- a/calhoun/ip.tf
+++ b/calhoun/ip.tf
@@ -1,0 +1,9 @@
+resource "google_compute_global_address" "ingress_ip" {
+  count = var.enable ? 1 : 0
+
+  provider = google.target
+  project  = var.google_project
+
+  name = "terra-${var.cluster}-${local.owner}-${local.service}-ip"
+}
+

--- a/calhoun/main.tf
+++ b/calhoun/main.tf
@@ -1,0 +1,9 @@
+/**
+ * # Terra calhon module
+ * 
+ * For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
+ * and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+ *
+ * This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+ * `terraform-docs markdown --no-sort . > README.md`
+ */

--- a/calhoun/main.tf
+++ b/calhoun/main.tf
@@ -1,5 +1,5 @@
 /**
- * # Terra calhon module
+ * # Terra calhoun module
  * 
  * For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
  * and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).

--- a/calhoun/outputs.tf
+++ b/calhoun/outputs.tf
@@ -1,0 +1,11 @@
+#
+# IP/DNS Outputs
+#
+output "ingress_ip" {
+  value       = var.enable ? google_compute_global_address.ingress_ip[0].address : null
+  description = "Calhoun ingress IP"
+}
+output "fqdn" {
+  value       = var.enable ? local.fqdn : null
+  description = "Calhoun fully qualified domain name"
+}

--- a/calhoun/provider.tf
+++ b/calhoun/provider.tf
@@ -1,0 +1,7 @@
+provider "google" {
+  alias = "target"
+}
+
+provider "google" {
+  alias = "dns"
+}

--- a/calhoun/variables.tf
+++ b/calhoun/variables.tf
@@ -1,0 +1,66 @@
+#
+# General Vars
+#
+variable "dependencies" {
+  # See: https://github.com/hashicorp/terraform/issues/21418#issuecomment-495818852
+  type        = any
+  default     = []
+  description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
+}
+variable "enable" {
+  type        = bool
+  description = "Enable flag for this module. If set to false, no resources will be created."
+  default     = true
+}
+
+variable "google_project" {
+  type        = string
+  description = "The google project in which to create resources"
+}
+variable "cluster" {
+  type        = string
+  description = "Terra GKE cluster suffix, whatever is after terra-"
+}
+variable "cluster_short" {
+  type        = string
+  description = "Optional short cluster name"
+  default     = ""
+}
+variable "owner" {
+  type        = string
+  description = "Environment or developer. Defaults to TF workspace name if left blank."
+  default     = ""
+}
+locals {
+  owner   = var.owner == "" ? terraform.workspace : var.owner
+  service = "calhoun-k8s" # K8s suffix is here for dns testing purposes, will remove when ready to cut over
+}
+
+#
+# DNS vars
+#
+variable "dns_zone_name" {
+  type        = string
+  description = "DNS zone name"
+  default     = "dsp-envs"
+}
+variable "use_subdomain" {
+  type        = bool
+  description = "Whether to use a subdomain between the zone and hostname"
+  default     = true
+}
+variable "subdomain_name" {
+  type        = string
+  description = "Domain namespacing between zone and hostname"
+  default     = ""
+}
+variable "hostname" {
+  type        = string
+  description = "Service hostname"
+  default     = ""
+}
+locals {
+  hostname       = var.hostname == "" ? local.service : var.hostname
+  cluster_name   = var.cluster_short == "" ? var.cluster : var.cluster_short
+  subdomain_name = var.use_subdomain ? (var.subdomain_name == "" ? ".${local.owner}.${local.cluster_name}" : var.subdomain_name) : ""
+}

--- a/calhoun/variables.tf
+++ b/calhoun/variables.tf
@@ -33,7 +33,7 @@ variable "owner" {
 }
 locals {
   owner   = var.owner == "" ? terraform.workspace : var.owner
-  service = "calhoun-k8s" # K8s suffix is here for dns testing purposes, will remove when ready to cut over
+  service = "calhoun"
 }
 
 #


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2746

Add calhoun module to Terraform. Just specifies IP and DNS resources.

Friends with: https://github.com/broadinstitute/terraform-ap-deployments/pull/335

Plan looks good: https://github.com/broadinstitute/terraform-ap-deployments/pull/335#issuecomment-863223289