### PR TITLE
[PF-810] new roles for bucket transfer

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.1"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=jaycarlton-google-storage-xfer-roles"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -21,7 +21,10 @@ locals {
     "roles/cloudprofiler.agent", # Profiling
     "roles/cloudtrace.agent", # Tracing for monitoring
     "roles/monitoring.editor", # Exporting metrics
-    "roles/pubsub.editor" # Creating, publishing & subscribing pub/sub topics for multi-instance Stairway.
+    "roles/pubsub.editor", # Creating, publishing & subscribing pub/sub topics for multi-instance Stairway.
+    "roles/storage.objectViewer", # read source bucket objects for storage transfer
+    "roles/storage.legacyBucketReader", # read source bucket for storage transfer
+    "roles/storage.legacyBucketWriter", # write sink bucket for storage transfer
   ]
 
   # Roles used to manage created workspace projects.


### PR DESCRIPTION
<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
Provide necessary permissions for storage transfer service to the main service account. These are documented [here](https://cloud.google.com/storage-transfer/docs/iam-transfer). 