### PR TITLE
PF-829: Module to create a project + SA for running CLI tests.

### DIFF
--- a/cli-test/README.md
+++ b/cli-test/README.md
@@ -1,0 +1,50 @@
+# cli-test
+
+This terraform module defines the resources needed for running
+[CLI](https://github.com/DataBiosphere/terra-cli) tests.
+
+For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
+and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+
+This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+`terraform-docs markdown --no-sort . > README.md`
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| google | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| enable-services | github.com/broadinstitute/terraform-shared.git//terraform-modules/api-services | services-0.3.0-tf-0.12 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| google_billing_account_iam_member.cli_test_admin | resource |
+| google_project.project | resource |
+| google_project_iam_member.cli_test_admin | resource |
+| google_service_account.cli_test_admin | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| google\_project | The google project id to create for CLI to run tests in. | `string` | n/a | yes |
+| folder\_id | What folder to create google\_project in. | `string` | n/a | yes |
+| billing\_account\_id | What billing account to assign google\_project. | `string` | n/a | yes |
+| enable\_billing\_user | Whether to set the CLI test SA as a billing user on the billing account. | `bool` | `true` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| service\_account\_email\_admin | CLI Test Admin Google service account email |

--- a/cli-test/README.md
+++ b/cli-test/README.md
@@ -38,7 +38,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| google\_project | The google project id to create for CLI to run tests in. | `string` | n/a | yes |
+| google\_project | The google project id to create for the CLI to create resources in | `string` | n/a | yes |
 | folder\_id | What folder to create google\_project in. | `string` | n/a | yes |
 | billing\_account\_id | What billing account to assign google\_project. | `string` | n/a | yes |
 | enable\_billing\_user | Whether to set the CLI test SA as a billing user on the billing account. | `bool` | `true` | no |

--- a/cli-test/api-services.tf
+++ b/cli-test/api-services.tf
@@ -1,0 +1,20 @@
+module "enable-services" {
+  source      = "github.com/broadinstitute/terraform-shared.git//terraform-modules/api-services?ref=services-0.3.0-tf-0.12"
+  enable_flag = "1"
+  providers = {
+    google.target = google.target
+  }
+  project = google_project.project.name
+  services = [
+    # APIs needed by CRL functionality.
+    "cloudtrace.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+
+    # APIs exercised by CLI tests.
+    "storage-api.googleapis.com",
+    "storage-component.googleapis.com",
+    "bigquery.googleapis.com",
+    "iam.googleapis.com",
+  ]
+}

--- a/cli-test/main.tf
+++ b/cli-test/main.tf
@@ -1,0 +1,12 @@
+/**
+ * # cli-test
+ *
+ * This terraform module defines the resources needed for running
+ * [CLI](https://github.com/DataBiosphere/terra-cli) tests.
+ * 
+ * For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
+ * and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
+ *
+ * This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
+ * `terraform-docs markdown --no-sort . > README.md`
+ */

--- a/cli-test/outputs.tf
+++ b/cli-test/outputs.tf
@@ -1,0 +1,10 @@
+#
+# Service Account Outputs
+# User of this module is expected to create the google_service_account_key resource and store the key for the
+# output service accounts.
+#
+
+output "service_account_email_admin" {
+  value       = google_service_account.cli_test_admin.email
+  description = "CLI Test Admin Google service account email"
+}

--- a/cli-test/project.tf
+++ b/cli-test/project.tf
@@ -1,3 +1,4 @@
+# Project for the CLI tests to create resources in.
 resource "google_project" "project" {
   name                = var.google_project
   project_id          = var.google_project

--- a/cli-test/project.tf
+++ b/cli-test/project.tf
@@ -1,0 +1,7 @@
+resource "google_project" "project" {
+  name                = var.google_project
+  project_id          = var.google_project
+  billing_account     = var.billing_account_id
+  folder_id           = var.folder_id
+  auto_create_network = false
+}

--- a/cli-test/provider.tf
+++ b/cli-test/provider.tf
@@ -1,0 +1,3 @@
+provider "google" {
+  alias = "target"
+}

--- a/cli-test/provider.tf
+++ b/cli-test/provider.tf
@@ -1,3 +1,0 @@
-provider "google" {
-  alias = "target"
-}

--- a/cli-test/service_accounts.tf
+++ b/cli-test/service_accounts.tf
@@ -1,0 +1,33 @@
+# Service account for the CLI tests to use to create resources in the project.
+resource "google_service_account" "cli_test_admin" {
+  project      = google_project.project.name
+  account_id   = "cli-test-admin"
+  display_name = "cli-test-admin"
+}
+
+locals {
+  roles = [
+    # Roles needed by CRL.
+    "roles/cloudtrace.agent",
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+
+    # Roles used in CLI tests.
+    "roles/storage.admin",
+    "roles/bigquery.admin",
+  ]
+}
+
+resource "google_project_iam_member" "cli_test_admin" {
+  count   = length(local.roles)
+  project = google_project.project.name
+  role    = local.roles[count.index]
+  member  = "serviceAccount:${google_service_account.cli_test_admin.email}"
+}
+
+resource "google_billing_account_iam_member" "cli_test_admin" {
+  count              = var.enable_billing_user ? 1 : 0
+  billing_account_id = var.billing_account_id
+  role               = "roles/billing.user"
+  member             = "serviceAccount:${google_service_account.cli_test_admin.email}"
+}

--- a/cli-test/variables.tf
+++ b/cli-test/variables.tf
@@ -1,5 +1,5 @@
 variable "google_project" {
-  description = "The google project id to create for CLI to run tests in."
+  description = "The google project id to create for the CLI to create resources in."
   type        = string
 }
 

--- a/cli-test/variables.tf
+++ b/cli-test/variables.tf
@@ -1,0 +1,23 @@
+variable "google_project" {
+  description = "The google project id to create for CLI to run tests in."
+  type        = string
+}
+
+variable "folder_id" {
+  type        = string
+  description = "What folder to create google_project in."
+}
+
+variable "billing_account_id" {
+  type        = string
+  description = "What billing account to assign google_project."
+}
+
+# We separate whether the roles/billing.user is set on the CLI test SA as its own flag because the
+# Broad SA that runs terraform does not want to have the broad permissions to set modify
+# permissions on the service account. This was done manually instead for the Broad.
+variable "enable_billing_user" {
+  type        = bool
+  description = "Whether to set the CLI test SA as a billing user on the billing account."
+  default     = true
+}


### PR DESCRIPTION
Create a new module `cli-test` to create a Google project and service account for running CLI tests. The CLI tests will use the service account to create buckets and BigQuery datasets in the project.

This is mostly copied from the existing `crl-test` module and deployment, but the CLI doesn't need a folder or a second SA.

The accompanying `terraform-ap-deployments` PR is [here](https://github.com/broadinstitute/terraform-ap-deployments/pull/353).