### PR TITLE
[PF-814] add bigQuery data transfer svc

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=jaycarlton-PF-813"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.2"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.1"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=jaycarlton-PF-813"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-workspace-manager/api-services.tf
+++ b/terra-workspace-manager/api-services.tf
@@ -13,6 +13,7 @@ module "enable-services" {
     "monitoring.googleapis.com",
     "storage-api.googleapis.com",
     "storage-component.googleapis.com",
-    "storagetransfer.googleapis.com"
+    "storagetransfer.googleapis.com",
+    "bigquerydatatransfer.googleapis.com"
   ]
 }


### PR DESCRIPTION
<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
Add the service `bigquerydatatransfer.googleapis.com` to support BigQuery dataset clone functionality.