### PR TITLE
[PF-814] add serviceAccountTokenCreator

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -70,9 +70,8 @@ module "sam" {
   firestore_billing_account_id = var.sam_firestore_billing_account_id
   firestore_folder_id          = var.sam_firestore_folder_id
 }
-
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.4"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.5"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=jaycarlton-token-creator"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.4"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -71,7 +71,7 @@ module "sam" {
   firestore_folder_id          = var.sam_firestore_folder_id
 }
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.5"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.6"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -72,7 +72,7 @@ module "sam" {
 }
 
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.3"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=jaycarlton-token-creator"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -22,7 +22,8 @@ locals {
     "roles/cloudtrace.agent", # Tracing for monitoring
     "roles/monitoring.editor", # Exporting metrics
     "roles/pubsub.editor", # Creating, publishing & subscribing pub/sub topics for multi-instance Stairway.
-    "roles/bigquery.admin" # working with Data Transfer Service
+    "roles/bigquery.admin", # working with Data Transfer Service
+    "roles/iam.serviceAccountTokenCreator" # working with account tokens
   ]
 
   # Roles used to manage created workspace projects.


### PR DESCRIPTION
<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
According to this error message, I need to have the `serviceAccountTokenCreator` role on the main control plane service account:
```
com.google.api.gax.rpc.FailedPreconditionException: io.grpc.StatusRuntimeException:
FAILED_PRECONDITION: P4 service account needs iam.serviceAccounts.getAccessToken permission.
Running the following command may resolve this error:
gcloud iam service-accounts add-iam-policy-binding workspace-wsmtest@terra-kernel-k8s.iam.gserviceaccount.com
  --member='serviceAccount:service-157747328908@gcp-sa-bigquerydatatransfer.iam.gserviceaccount.com'
  --role='roles/iam.serviceAccountTokenCreator'
```