### PR TITLE
[PF-814] getIamPolicy and setIamPolicy permissions

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -71,7 +71,7 @@ module "sam" {
   firestore_folder_id          = var.sam_firestore_folder_id
 }
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.6"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=jaycarlton-getiampolicy"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -71,7 +71,7 @@ module "sam" {
   firestore_folder_id          = var.sam_firestore_folder_id
 }
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=jaycarlton-getiampolicy"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.7"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -23,7 +23,8 @@ locals {
     "roles/monitoring.editor", # Exporting metrics
     "roles/pubsub.editor", # Creating, publishing & subscribing pub/sub topics for multi-instance Stairway.
     "roles/bigquery.admin", # working with Data Transfer Service
-    "roles/iam.serviceAccountTokenCreator" # working with account tokens
+    "roles/iam.serviceAccountTokenCreator", # working with account tokens
+    "roles/composer.ServiceAgentV2Ext" # get & set IAM policies
   ]
 
   # Roles used to manage created workspace projects.

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -24,7 +24,7 @@ locals {
     "roles/pubsub.editor", # Creating, publishing & subscribing pub/sub topics for multi-instance Stairway.
     "roles/bigquery.admin", # working with Data Transfer Service
     "roles/iam.serviceAccountTokenCreator", # working with account tokens
-    "roles/composer.ServiceAgentV2Ext" # get & set IAM policies
+    "roles/composer.ServiceAgentV2Ext" # get & set IAM policies for BigQuery Data Transfer Service
   ]
 
   # Roles used to manage created workspace projects.


### PR DESCRIPTION
<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
The role `roles/composer.ServiceAgentV2Ext` contains exactly getIamPolicy and setIamPolicy, which are what I need to enable the P4 service account to impersonate the main service account.