### PR TITLE
[PF-814] remove storage transfer storage helpers

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -71,7 +71,7 @@ module "sam" {
   firestore_folder_id          = var.sam_firestore_folder_id
 }
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.7"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=jaycarlton-restore"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -71,7 +71,7 @@ module "sam" {
   firestore_folder_id          = var.sam_firestore_folder_id
 }
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=jaycarlton-restore"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.8"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-workspace-manager/api-services.tf
+++ b/terra-workspace-manager/api-services.tf
@@ -13,7 +13,6 @@ module "enable-services" {
     "monitoring.googleapis.com",
     "storage-api.googleapis.com",
     "storage-component.googleapis.com",
-    "storagetransfer.googleapis.com",
-    "bigquerydatatransfer.googleapis.com"
+    "storagetransfer.googleapis.com"
   ]
 }

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -21,10 +21,7 @@ locals {
     "roles/cloudprofiler.agent", # Profiling
     "roles/cloudtrace.agent", # Tracing for monitoring
     "roles/monitoring.editor", # Exporting metrics
-    "roles/pubsub.editor", # Creating, publishing & subscribing pub/sub topics for multi-instance Stairway.
-    "roles/bigquery.admin", # working with Data Transfer Service
-    "roles/iam.serviceAccountTokenCreator", # working with account tokens
-    "roles/composer.ServiceAgentV2Ext" # get & set IAM policies for BigQuery Data Transfer Service
+    "roles/pubsub.editor" # Creating, publishing & subscribing pub/sub topics for multi-instance Stairway.
   ]
 
   # Roles used to manage created workspace projects.


### PR DESCRIPTION
<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->

We are no longer using BigQuery Data Transfer Service for workspace clone, and don't need these roles and API anymore.