### PR TITLE
AS-608: Add deployer SA as serviceAccountUser on streamer SA [delta layer]

### DIFF
--- a/deltalayer/sa.tf
+++ b/deltalayer/sa.tf
@@ -38,3 +38,11 @@ resource "google_project_iam_member" "sa" {
   role     = "roles/cloudfunctions.admin"
   member   = "serviceAccount:${google_service_account.sa_deployer[0].email}"
 }
+
+# Grants the deployer service account the ability to launch the Cloud
+# Function as the streamer service account
+resource "google_service_account_iam_member" "sa_streamer" {
+  service_account_id = google_service_account.sa_streamer[0].account_id
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.sa_deployer[0].email}"
+}

--- a/deltalayer/sa.tf
+++ b/deltalayer/sa.tf
@@ -42,7 +42,7 @@ resource "google_project_iam_member" "sa" {
 # Grants the deployer service account the ability to launch the Cloud
 # Function as the streamer service account
 resource "google_service_account_iam_member" "sa_streamer" {
-  service_account_id = google_service_account.sa_streamer[0].account_id
+  service_account_id = google_service_account.sa_streamer[0].email
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.sa_deployer[0].email}"
 }

--- a/deltalayer/sa.tf
+++ b/deltalayer/sa.tf
@@ -41,8 +41,8 @@ resource "google_project_iam_member" "sa" {
 
 # Grants the deployer service account the ability to launch the Cloud
 # Function as the streamer service account
-resource "google_service_account_iam_member" "sa_streamer" {
-  service_account_id = google_service_account.sa_streamer[0].email
+resource "google_service_account_iam_member" "sa_streamer_iam" {
+  service_account_id = google_service_account.sa_streamer[0].name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.sa_deployer[0].email}"
 }


### PR DESCRIPTION
Here's the uninteresting deployments PR: https://github.com/broadinstitute/terraform-ap-deployments/pull/393

This change is needed because the deployer SA specifies `--service-account=deltalayer-dev-streamer@broad-dsde-dev.iam.gserviceaccount.com` during deployment, and in order to do so, the deployer SA needs the serviceAccountUser role on the streamer SA