### PR TITLE
Add JWT signing role [POL-41]

### DIFF
--- a/externalcreds/README.md
+++ b/externalcreds/README.md
@@ -7,7 +7,7 @@ For more information, check out the [MC-Terra deployment doc](https://docs.dsp-d
 and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
 
 This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
-`terraform-docs markdown --no-sort . > README.md`
+`terraform-docs markdown . > README.md`
 
 ## Requirements
 

--- a/externalcreds/sa.tf
+++ b/externalcreds/sa.tf
@@ -18,9 +18,10 @@ resource "google_project_iam_member" "sqlproxy" {
 
 locals {
   app_sa_roles = [
-    "roles/cloudprofiler.agent", # Profiling
-    "roles/cloudtrace.agent",    # Tracing for monitoring
-    "roles/monitoring.editor",   # Exporting metrics
+    "roles/cloudprofiler.agent",            # Profiling
+    "roles/cloudtrace.agent",               # Tracing for monitoring
+    "roles/monitoring.editor",              # Exporting metrics
+    "roles/iam.serviceAccountTokenCreator", # For signing JWTs
   ]
 }
 


### PR DESCRIPTION
Adds a role for the ECM app service account to sign JWTs. 

[Link to ticket](https://broadworkbench.atlassian.net/browse/POL-41)
