### PR TITLE
[DDO-1542] Fix Storage Admin Role Membership for Terra Envs

### DIFF
--- a/testrunner/README.md
+++ b/testrunner/README.md
@@ -1,16 +1,10 @@
 # Terra testrunner module
 
-This module creates infrastructure resources for TestRunner in Terra environments.
-
 For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
 and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
 
 This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
 `terraform-docs markdown --no-sort . > README.md`
-
-## Specification
-
-This [document](https://docs.google.com/document/d/1wP6OR9OKRK9-QZ6W2jvzjJPqfb8tlQkmm-GP-m_4rKo) describes the specific resources required for `TestRunner` to run tests and publish test results.
 
 ## Requirements
 
@@ -31,23 +25,27 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_project_iam_member.bq_streamer_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.bq_testrunner_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.cf_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.k8s_engine_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.storage_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.firecloud_sa_project_iam_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.leonardo_sa_project_iam_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.sam_sa_project_iam_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.testrunner_cf_deployer_sa_project_iam_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.testrunner_sa_project_iam_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.testrunner_streamer_sa_project_iam_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_pubsub_topic.testrunner_results_bucket_topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
-| [google_pubsub_topic_iam_member.testrunner_results_bucket_topic_publish_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
+| [google_pubsub_topic_iam_member.gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
 | [google_service_account.testrunner_cf_deployer_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
-| [google_service_account.testrunner_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.testrunner_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.testrunner_streamer_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
-| [google_service_account_iam_member.appspot_iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
-| [google_service_account_iam_member.testrunner_streamer_sa_iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_account_iam_member.testrunner_cf_deployer_sa_runas_default_appspot_sa_service_account_iam_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_account_iam_member.testrunner_cf_deployer_sa_runas_testrunner_streamer_sa_service_account_iam_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_storage_bucket.testrunner-results-bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
-| [google_storage_bucket_iam_member.testrunner-results-bucket-admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+| [google_storage_bucket_iam_member.testrunner_streamer_sa_storage_bucket_iam_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_notification.testrunner-results-finalize-notification](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_notification) | resource |
-| [google_app_engine_default_service_account.default_appspot](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/app_engine_default_service_account) | data source |
-| [google_storage_project_service_account.gcs_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account) | data source |
+| [google_app_engine_default_service_account.default_appspot_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/app_engine_default_service_account) | data source |
+| [google_service_account.firecloud_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account) | data source |
+| [google_service_account.leonardo_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account) | data source |
+| [google_service_account.sam_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account) | data source |
+| [google_storage_project_service_account.gsp_automatic_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account) | data source |
 
 ## Inputs
 
@@ -56,8 +54,19 @@ No modules.
 | <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Google region in which to create buckets | `string` | `"us-central1"` | no |
 | <a name="input_dependencies"></a> [dependencies](#input\_dependencies) | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
 | <a name="input_enable"></a> [enable](#input\_enable) | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
+| <a name="input_firecloud_sa_name"></a> [firecloud\_sa\_name](#input\_firecloud\_sa\_name) | n/a | `string` | `""` | no |
+| <a name="input_firecloud_sa_project_iam_roles"></a> [firecloud\_sa\_project\_iam\_roles](#input\_firecloud\_sa\_project\_iam\_roles) | A list of one or more roles to which the Firecloud SA will be added. | `list(string)` | <pre>[<br>  "roles/storage.admin"<br>]</pre> | no |
 | <a name="input_google_project"></a> [google\_project](#input\_google\_project) | The google project in which to create resources | `string` | n/a | yes |
+| <a name="input_gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_roles"></a> [gsp\_automatic\_sa\_testrunner\_results\_bucket\_pubsub\_topic\_publish\_iam\_roles](#input\_gsp\_automatic\_sa\_testrunner\_results\_bucket\_pubsub\_topic\_publish\_iam\_roles) | A list of one or more roles which the GSP Automatic SA will use to publish results to the TestRunner Results Bucket Topic. | `list(string)` | <pre>[<br>  "roles/pubsub.publisher"<br>]</pre> | no |
+| <a name="input_leonardo_sa_name"></a> [leonardo\_sa\_name](#input\_leonardo\_sa\_name) | n/a | `string` | `""` | no |
+| <a name="input_leonardo_sa_project_iam_roles"></a> [leonardo\_sa\_project\_iam\_roles](#input\_leonardo\_sa\_project\_iam\_roles) | A list of one or more roles to which the Leonardo SA will be added. | `list(string)` | <pre>[<br>  "roles/storage.admin"<br>]</pre> | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
+| <a name="input_sam_sa_name"></a> [sam\_sa\_name](#input\_sam\_sa\_name) | n/a | `string` | `""` | no |
+| <a name="input_sam_sa_project_iam_roles"></a> [sam\_sa\_project\_iam\_roles](#input\_sam\_sa\_project\_iam\_roles) | A list of one or more roles to which the Sam SA will be added. | `list(string)` | <pre>[<br>  "roles/storage.admin"<br>]</pre> | no |
+| <a name="input_testrunner_cf_deployer_sa_project_iam_roles"></a> [testrunner\_cf\_deployer\_sa\_project\_iam\_roles](#input\_testrunner\_cf\_deployer\_sa\_project\_iam\_roles) | A list of one or more roles to which the TestRunner Cloud Function Deployer SA will be added. | `list(string)` | <pre>[<br>  "roles/cloudfunctions.admin"<br>]</pre> | no |
+| <a name="input_testrunner_sa_project_iam_roles"></a> [testrunner\_sa\_project\_iam\_roles](#input\_testrunner\_sa\_project\_iam\_roles) | A list of one or more roles to which the TestRunner SA will be added. | `list(string)` | <pre>[<br>  "roles/bigquery.user",<br>  "roles/container.viewer",<br>  "roles/storage.admin"<br>]</pre> | no |
+| <a name="input_testrunner_streamer_sa_project_iam_roles"></a> [testrunner\_streamer\_sa\_project\_iam\_roles](#input\_testrunner\_streamer\_sa\_project\_iam\_roles) | A list of one or more project roles to which the TestRunner Streamer SA will be added. | `list(string)` | <pre>[<br>  "roles/bigquery.user"<br>]</pre> | no |
+| <a name="input_testrunner_streamer_sa_storage_bucket_iam_roles"></a> [testrunner\_streamer\_sa\_storage\_bucket\_iam\_roles](#input\_testrunner\_streamer\_sa\_storage\_bucket\_iam\_roles) | A list of one or more storage bucket roles to which the TestRunner Streamer SA will be added. | `list(string)` | <pre>[<br>  "roles/storage.admin"<br>]</pre> | no |
 
 ## Outputs
 

--- a/testrunner/buckets.tf
+++ b/testrunner/buckets.tf
@@ -9,10 +9,11 @@ resource "google_storage_bucket" "testrunner-results-bucket" {
   uniform_bucket_level_access = true
 }
 
-resource "google_storage_bucket_iam_member" "testrunner-results-bucket-admin" {
+resource "google_storage_bucket_iam_member" "testrunner_streamer_sa_storage_bucket_iam_role" {
+  count = length(var.testrunner_streamer_sa_storage_bucket_iam_roles)
   bucket = google_storage_bucket.testrunner-results-bucket.name
-  role = "roles/storage.admin"
-  member = google_service_account.testrunner_streamer_sa[0].email
+  role    = element(var.testrunner_streamer_sa_storage_bucket_iam_roles, count.index)
+  member  = "serviceAccount:${google_service_account.testrunner_streamer_sa[0].email}"
 }
 
 # Pub/Sub notifications for object-finalize in the TestRunner results bucket.
@@ -27,5 +28,5 @@ resource "google_storage_notification" "testrunner-results-finalize-notification
   payload_format = "JSON_API_V1"
   topic          = google_pubsub_topic.testrunner_results_bucket_topic.id
   event_types    = ["OBJECT_FINALIZE"]
-  depends_on     = [google_pubsub_topic_iam_member.testrunner_results_bucket_topic_publish_policy]
+  depends_on     = [google_pubsub_topic_iam_member.gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_role]
 }

--- a/testrunner/buckets.tf
+++ b/testrunner/buckets.tf
@@ -10,10 +10,10 @@ resource "google_storage_bucket" "testrunner-results-bucket" {
 }
 
 resource "google_storage_bucket_iam_member" "testrunner_streamer_sa_storage_bucket_iam_role" {
-  count = length(var.testrunner_streamer_sa_storage_bucket_iam_roles)
+  count  = length(var.testrunner_streamer_sa_storage_bucket_iam_roles)
   bucket = google_storage_bucket.testrunner-results-bucket.name
-  role    = element(var.testrunner_streamer_sa_storage_bucket_iam_roles, count.index)
-  member  = "serviceAccount:${google_service_account.testrunner_streamer_sa[0].email}"
+  role   = element(var.testrunner_streamer_sa_storage_bucket_iam_roles, count.index)
+  member = "serviceAccount:${google_service_account.testrunner_streamer_sa[0].email}"
 }
 
 # Pub/Sub notifications for object-finalize in the TestRunner results bucket.

--- a/testrunner/outputs.tf
+++ b/testrunner/outputs.tf
@@ -3,7 +3,7 @@
 #
 
 output "testrunner_sa_id" {
-  value       = google_service_account.testrunner_service_account[0].account_id
+  value       = google_service_account.testrunner_sa[0].account_id
   description = "TestRunner service account id"
 }
 

--- a/testrunner/pubsub.tf
+++ b/testrunner/pubsub.tf
@@ -2,9 +2,9 @@
 
 # Pubsub topic for TestRunner results bucket's Storage Object Events.
 resource "google_pubsub_topic" "testrunner_results_bucket_topic" {
-  provider  = google.target
-  project   = var.google_project
-  name      = "testrunner-results-bucket-topic"
+  provider = google.target
+  project  = var.google_project
+  name     = "testrunner-results-bucket-topic"
 }
 
 # N.B. no need to create subscriptions; subscriptions are automatically created when the relevant
@@ -12,16 +12,16 @@ resource "google_pubsub_topic" "testrunner_results_bucket_topic" {
 
 # automatic SA for this project: https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account
 data "google_storage_project_service_account" "gsp_automatic_sa" {
-  provider  = google.target
-  project   = var.google_project
+  provider = google.target
+  project  = var.google_project
 }
 
 # permission for automatic SA to publish to source topic
 resource "google_pubsub_topic_iam_member" "gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_role" {
-  provider  = google.target
-  project   = var.google_project
-  topic     = google_pubsub_topic.testrunner_results_bucket_topic.name
-  count     = length(var.gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_roles)
-  role      = element(var.gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_roles, count.index)
-  member    = "serviceAccount:${data.google_storage_project_service_account.gsp_automatic_sa.email_address}"
+  provider = google.target
+  project  = var.google_project
+  topic    = google_pubsub_topic.testrunner_results_bucket_topic.name
+  count    = length(var.gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_roles)
+  role     = element(var.gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_roles, count.index)
+  member   = "serviceAccount:${data.google_storage_project_service_account.gsp_automatic_sa.email_address}"
 }

--- a/testrunner/pubsub.tf
+++ b/testrunner/pubsub.tf
@@ -2,25 +2,26 @@
 
 # Pubsub topic for TestRunner results bucket's Storage Object Events.
 resource "google_pubsub_topic" "testrunner_results_bucket_topic" {
-  provider = google.target
-  project  = var.google_project
-  name     = "testrunner-results-bucket-topic"
+  provider  = google.target
+  project   = var.google_project
+  name      = "testrunner-results-bucket-topic"
 }
 
 # N.B. no need to create subscriptions; subscriptions are automatically created when the relevant
 # Cloud Functions are deployed.
 
 # automatic SA for this project: https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account
-data "google_storage_project_service_account" "gcs_account" {
-  provider = google.target
-  project  = var.google_project
+data "google_storage_project_service_account" "gsp_automatic_sa" {
+  provider  = google.target
+  project   = var.google_project
 }
 
 # permission for automatic SA to publish to source topic
-resource "google_pubsub_topic_iam_member" "testrunner_results_bucket_topic_publish_policy" {
-  provider = google.target
-  project  = var.google_project
-  topic    = google_pubsub_topic.testrunner_results_bucket_topic.name
-  role     = "roles/pubsub.publisher"
-  member   = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
+resource "google_pubsub_topic_iam_member" "gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_role" {
+  provider  = google.target
+  project   = var.google_project
+  topic     = google_pubsub_topic.testrunner_results_bucket_topic.name
+  count     = length(var.gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_roles)
+  role      = element(var.gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_roles, count.index)
+  member    = "serviceAccount:${data.google_storage_project_service_account.gsp_automatic_sa.email_address}"
 }

--- a/testrunner/sa.tf
+++ b/testrunner/sa.tf
@@ -83,3 +83,47 @@ resource "google_project_iam_member" "testrunner_streamer_sa_iam_role" {
   role    = "${element(var.testrunner_streamer_sa_iam_roles, count.index)}"
   member  = "serviceAccount:${google_service_account.testrunner_streamer_sa[0].email}"
 }
+
+## The following entities were added on 24 Sep 2021 as part of a temporary
+## workaround to addres the IAM storage.admin role SA membership issue that
+## manifested as part of QA-1485 and QA-1526. See JIRA issue DDO-1542 for details.
+#
+# These variables will need to remain in this file until the following items are
+# complete:
+# - The changes for QA-1526 have been merged to master in terraform-ap-modules and
+#   terraform-ap-deployments.
+# - The changes required to manage these non-TestRunner entities have been moved
+#   to a common IAM module.
+
+data "google_service_account" "firecloud_sa" {
+  account_id = var.firecloud_sa_name
+}
+
+data "google_service_account" "leonardo_sa" {
+  account_id = var.leonardo_sa_name
+}
+
+data "google_service_account" "sam_sa" {
+  account_id = var.sam_sa_name
+}
+
+resource "google_project_iam_member" "firecloud_sa_iam_role" {
+  count = "${length(var.firecloud_sa_iam_roles)}"
+  project = var.google_project
+  role    = "${element(var.firecloud_sa_iam_roles, count.index)}"
+  member  = "serviceAccount:${google_service_account.firecloud_sa[0].email}"
+}
+
+resource "google_project_iam_member" "sam_sa_iam_role" {
+  count = "${length(var.sam_sa_iam_roles)}"
+  project = var.google_project
+  role    = "${element(var.sam_sa_iam_roles, count.index)}"
+  member  = "serviceAccount:${google_service_account.sam_sa[0].email}"
+}
+
+resource "google_project_iam_member" "leonardo_sa_iam_role" {
+  count = "${length(var.leonardo_sa_iam_roles)}"
+  project = var.google_project
+  role    = "${element(var.leonardo_sa_iam_roles, count.index)}"
+  member  = "serviceAccount:${google_service_account.leonardo_sa[0].email}"
+}

--- a/testrunner/sa.tf
+++ b/testrunner/sa.tf
@@ -2,24 +2,22 @@
 
 # Main service account (assume this is for general operations?)
 resource "google_service_account" "testrunner_sa" {
-  count = var.enable ? 1 : 0
-
-  provider     = google.target
-  project      = var.google_project
-  account_id   = "${local.service}-${local.owner}"
-  display_name = "${local.service}-${local.owner}"
-  description  = "The IAM Service Account for TestRunner"
+  count         = var.enable ? 1 : 0
+  provider      = google.target
+  project       = var.google_project
+  account_id    = "${local.service}-${local.owner}"
+  display_name  = "${local.service}-${local.owner}"
+  description   = "The IAM Service Account for TestRunner"
 }
 
 # Service account for deploying the TestRunner-related cloud functions.
 resource "google_service_account" "testrunner_cf_deployer_sa" {
-  count = var.enable ? 1 : 0
-
-  provider     = google.target
-  project      = var.google_project
-  account_id   = "${local.service}-${local.owner}-cf-deployer"
-  display_name = "${local.service}-${local.owner}-cf-deployer"
-  description  = "The Service Account for deploying TestRunner Cloud Functions"
+  count         = var.enable ? 1 : 0
+  provider      = google.target
+  project       = var.google_project
+  account_id    = "${local.service}-${local.owner}-cf-deployer"
+  display_name  = "${local.service}-${local.owner}-cf-deployer"
+  description   = "The Service Account for deploying TestRunner Cloud Functions"
 }
 
 # Service account for the TestRunner "streamer" cloud function.
@@ -28,13 +26,12 @@ resource "google_service_account" "testrunner_cf_deployer_sa" {
 # 2) Open a channel / input stream to the file object in the bucket.
 # 3) Stream data to BigQuery.
 resource "google_service_account" "testrunner_streamer_sa" {
-  count = var.enable ? 1 : 0
-
-  provider     = google.target
-  project      = var.google_project
-  account_id   = "${local.service}-${local.owner}-streamer"
-  display_name = "${local.service}-${local.owner}-streamer"
-  description  = "The Service Account for TestRunner Streamer Cloud Functions"
+  count         = var.enable ? 1 : 0
+  provider      = google.target
+  project       = var.google_project
+  account_id    = "${local.service}-${local.owner}-streamer"
+  display_name  = "${local.service}-${local.owner}-streamer"
+  description   = "The Service Account for TestRunner Streamer Cloud Functions"
 }
 
 data "google_app_engine_default_service_account" "default_appspot_sa" {
@@ -51,41 +48,48 @@ data "google_app_engine_default_service_account" "default_appspot_sa" {
 #     the Google project used for the deployment of TestRunner Cloud Functions,
 #     so we apply the permission to that Google project here instead of in a
 #     google-project.tf module
+#
 # 3.  Grants the deployer SA the ability to use TestRunner streamer SA.
 #     This allows, for example, the Cloud Function deployer SA to stand up the relevant Cloud Function as streamer.
+#
 # 4.  Grants the deployer service account the ability to act as
 #     <project-id>@appspot.gserviceaccount.com
 
-resource "google_project_iam_member" "testrunner_sa_iam_role" {
-  count = "${length(var.testrunner_sa_iam_roles)}"
+resource "google_project_iam_member" "testrunner_sa_project_iam_role" {
+  count   = length(var.testrunner_sa_project_iam_roles)
   project = var.google_project
-  role    = "${element(var.testrunner_sa_iam_roles, count.index)}"
+  role    = element(var.testrunner_sa_project_iam_roles, count.index)
   member  = "serviceAccount:${google_service_account.testrunner_sa[0].email}"
 }
 
-resource "google_project_iam_member" "testrunner_cf_deployer_sa_iam_role" {
-  count = "${length(var.testrunner_cf_deployer_sa_iam_roles)}"
+resource "google_project_iam_member" "testrunner_cf_deployer_sa_project_iam_role" {
+  count   = length(var.testrunner_cf_deployer_sa_project_iam_roles)
   project = var.google_project
-  role    = "${element(var.testrunner_cf_deployer_sa_iam_roles, count.index)}"
+  role    = element(var.testrunner_cf_deployer_sa_project_iam_roles, count.index)
   member  = "serviceAccount:${google_service_account.testrunner_cf_deployer_sa[0].email}"
 }
 
-resource "google_service_account_iam_member" "testrunner_cf_deployer_sa_runas_default_appspot_sa_iam_role" {
-  count = "${length(var.testrunner_cf_deployer_sa_runas_default_appspot_sa_iam_roles)}"
-  service_account_id = data.google_app_engine_default_service_account.default_appspot_sa.name
-  role    = "${element(var.testrunner_cf_deployer_sa_runas_default_appspot_sa_iam_roles, count.index)}"
-  member  = "serviceAccount:${google_service_account.testrunner_cf_deployer_sa[0].email}"
+resource "google_service_account_iam_member" "testrunner_cf_deployer_sa_runas_default_appspot_sa_service_account_iam_role" {
+  service_account_id  = data.google_app_engine_default_service_account.default_appspot_sa.name
+  role                = "roles/iam.serviceAccountUser"
+  member              = "serviceAccount:${google_service_account.testrunner_cf_deployer_sa[0].email}"
 }
 
-resource "google_project_iam_member" "testrunner_streamer_sa_iam_role" {
-  count = "${length(var.testrunner_streamer_sa_iam_roles)}"
+resource "google_service_account_iam_member" "testrunner_cf_deployer_sa_runas_testrunner_streamer_sa_service_account_iam_role" {
+  service_account_id  = google_service_account.testrunner_streamer_sa[0].name
+  role                = "roles/iam.serviceAccountUser"
+  member              = "serviceAccount:${google_service_account.testrunner_cf_deployer_sa[0].email}"
+}
+
+resource "google_project_iam_member" "testrunner_streamer_sa_project_iam_role" {
+  count   = length(var.testrunner_streamer_sa_project_iam_roles)
   project = var.google_project
-  role    = "${element(var.testrunner_streamer_sa_iam_roles, count.index)}"
+  role    = element(var.testrunner_streamer_sa_project_iam_roles, count.index)
   member  = "serviceAccount:${google_service_account.testrunner_streamer_sa[0].email}"
 }
 
 ## The following entities were added on 24 Sep 2021 as part of a temporary
-## workaround to addres the IAM storage.admin role SA membership issue that
+## workaround to address the IAM storage.admin role SA membership issue that
 ## manifested as part of QA-1485 and QA-1526. See JIRA issue DDO-1542 for details.
 #
 # These variables will need to remain in this file until the following items are
@@ -107,23 +111,23 @@ data "google_service_account" "sam_sa" {
   account_id = var.sam_sa_name
 }
 
-resource "google_project_iam_member" "firecloud_sa_iam_role" {
-  count = "${length(var.firecloud_sa_iam_roles)}"
+resource "google_project_iam_member" "firecloud_sa_project_iam_role" {
+  count   = length(var.firecloud_sa_project_iam_roles)
   project = var.google_project
-  role    = "${element(var.firecloud_sa_iam_roles, count.index)}"
-  member  = "serviceAccount:${google_service_account.firecloud_sa[0].email}"
+  role    = element(var.firecloud_sa_project_iam_roles, count.index)
+  member  = "serviceAccount:${data.google_service_account.firecloud_sa.email}"
 }
 
-resource "google_project_iam_member" "sam_sa_iam_role" {
-  count = "${length(var.sam_sa_iam_roles)}"
+resource "google_project_iam_member" "leonardo_sa_project_iam_role" {
+  count   = length(var.leonardo_sa_project_iam_roles)
   project = var.google_project
-  role    = "${element(var.sam_sa_iam_roles, count.index)}"
-  member  = "serviceAccount:${google_service_account.sam_sa[0].email}"
+  role    = element(var.leonardo_sa_project_iam_roles, count.index)
+  member  = "serviceAccount:${data.google_service_account.leonardo_sa.email}"
 }
 
-resource "google_project_iam_member" "leonardo_sa_iam_role" {
-  count = "${length(var.leonardo_sa_iam_roles)}"
+resource "google_project_iam_member" "sam_sa_project_iam_role" {
+  count   = length(var.sam_sa_project_iam_roles)
   project = var.google_project
-  role    = "${element(var.leonardo_sa_iam_roles, count.index)}"
-  member  = "serviceAccount:${google_service_account.leonardo_sa[0].email}"
+  role    = element(var.sam_sa_project_iam_roles, count.index)
+  member  = "serviceAccount:${data.google_service_account.sam_sa.email}"
 }

--- a/testrunner/sa.tf
+++ b/testrunner/sa.tf
@@ -2,22 +2,22 @@
 
 # Main service account (assume this is for general operations?)
 resource "google_service_account" "testrunner_sa" {
-  count         = var.enable ? 1 : 0
-  provider      = google.target
-  project       = var.google_project
-  account_id    = "${local.service}-${local.owner}"
-  display_name  = "${local.service}-${local.owner}"
-  description   = "The IAM Service Account for TestRunner"
+  count        = var.enable ? 1 : 0
+  provider     = google.target
+  project      = var.google_project
+  account_id   = "${local.service}-${local.owner}"
+  display_name = "${local.service}-${local.owner}"
+  description  = "The IAM Service Account for TestRunner"
 }
 
 # Service account for deploying the TestRunner-related cloud functions.
 resource "google_service_account" "testrunner_cf_deployer_sa" {
-  count         = var.enable ? 1 : 0
-  provider      = google.target
-  project       = var.google_project
-  account_id    = "${local.service}-${local.owner}-cf-deployer"
-  display_name  = "${local.service}-${local.owner}-cf-deployer"
-  description   = "The Service Account for deploying TestRunner Cloud Functions"
+  count        = var.enable ? 1 : 0
+  provider     = google.target
+  project      = var.google_project
+  account_id   = "${local.service}-${local.owner}-cf-deployer"
+  display_name = "${local.service}-${local.owner}-cf-deployer"
+  description  = "The Service Account for deploying TestRunner Cloud Functions"
 }
 
 # Service account for the TestRunner "streamer" cloud function.
@@ -26,12 +26,12 @@ resource "google_service_account" "testrunner_cf_deployer_sa" {
 # 2) Open a channel / input stream to the file object in the bucket.
 # 3) Stream data to BigQuery.
 resource "google_service_account" "testrunner_streamer_sa" {
-  count         = var.enable ? 1 : 0
-  provider      = google.target
-  project       = var.google_project
-  account_id    = "${local.service}-${local.owner}-streamer"
-  display_name  = "${local.service}-${local.owner}-streamer"
-  description   = "The Service Account for TestRunner Streamer Cloud Functions"
+  count        = var.enable ? 1 : 0
+  provider     = google.target
+  project      = var.google_project
+  account_id   = "${local.service}-${local.owner}-streamer"
+  display_name = "${local.service}-${local.owner}-streamer"
+  description  = "The Service Account for TestRunner Streamer Cloud Functions"
 }
 
 data "google_app_engine_default_service_account" "default_appspot_sa" {
@@ -70,15 +70,15 @@ resource "google_project_iam_member" "testrunner_cf_deployer_sa_project_iam_role
 }
 
 resource "google_service_account_iam_member" "testrunner_cf_deployer_sa_runas_default_appspot_sa_service_account_iam_role" {
-  service_account_id  = data.google_app_engine_default_service_account.default_appspot_sa.name
-  role                = "roles/iam.serviceAccountUser"
-  member              = "serviceAccount:${google_service_account.testrunner_cf_deployer_sa[0].email}"
+  service_account_id = data.google_app_engine_default_service_account.default_appspot_sa.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.testrunner_cf_deployer_sa[0].email}"
 }
 
 resource "google_service_account_iam_member" "testrunner_cf_deployer_sa_runas_testrunner_streamer_sa_service_account_iam_role" {
-  service_account_id  = google_service_account.testrunner_streamer_sa[0].name
-  role                = "roles/iam.serviceAccountUser"
-  member              = "serviceAccount:${google_service_account.testrunner_cf_deployer_sa[0].email}"
+  service_account_id = google_service_account.testrunner_streamer_sa[0].name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.testrunner_cf_deployer_sa[0].email}"
 }
 
 resource "google_project_iam_member" "testrunner_streamer_sa_project_iam_role" {

--- a/testrunner/variables.tf
+++ b/testrunner/variables.tf
@@ -28,7 +28,7 @@ variable "owner" {
   default     = ""
 }
 
-variable "testrunner_sa_iam_roles" {
+variable "testrunner_sa_project_iam_roles" {
   type        = list(string)
   description = "A list of one or more roles to which the TestRunner SA will be added."
   default     = [
@@ -38,7 +38,7 @@ variable "testrunner_sa_iam_roles" {
   ]
 }
 
-variable "testrunner_cf_deployer_sa_iam_roles" {
+variable "testrunner_cf_deployer_sa_project_iam_roles" {
   type        = list(string)
   description = "A list of one or more roles to which the TestRunner Cloud Function Deployer SA will be added."
   default     = [
@@ -46,20 +46,27 @@ variable "testrunner_cf_deployer_sa_iam_roles" {
   ]
 }
 
-variable "testrunner_cf_deployer_sa_runas_default_appspot_sa_iam_roles" {
+variable "testrunner_streamer_sa_project_iam_roles" {
   type        = list(string)
-  description = "A list of one or more roles which the TestRunner CF Deployer SA will be able to run as the Default AppSpot SA."
+  description = "A list of one or more project roles to which the TestRunner Streamer SA will be added."
   default     = [
-    "roles/iam.serviceAccountUser",
+    "roles/bigquery.user",
   ]
 }
 
-variable "testrunner_streamer_sa_iam_roles" {
+variable "testrunner_streamer_sa_storage_bucket_iam_roles" {
   type        = list(string)
-  description = "A list of one or more roles to which the TestRunner Streamer SA will be added."
+  description = "A list of one or more storage bucket roles to which the TestRunner Streamer SA will be added."
   default     = [
-    "roles/bigquery.user",
-    "roles/iam.serviceAccountUser",
+    "roles/storage.admin",
+  ]
+}
+
+variable "gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_roles" {
+  type        = list(string)
+  description = "A list of one or more roles which the GSP Automatic SA will use to publish results to the TestRunner Results Bucket Topic." 
+  default     = [
+    "roles/pubsub.publisher",
   ]
 }
 
@@ -69,7 +76,7 @@ locals {
 }
 
 ## The following entities were added on 24 Sep 2021 as part of a temporary
-## workaround to addres the IAM storage.admin role SA membership issue that
+## workaround to address the IAM storage.admin role SA membership issue that
 ## manifested as part of QA-1485 and QA-1526. See JIRA issue DDO-1542 for details.
 #
 # These variables will need to remain in this file until the following items are
@@ -79,7 +86,7 @@ locals {
 # - The changes required to manage these non-TestRunner entities have been moved
 #   to a common IAM module.
 
-variable "firecloud_sa_iam_roles" {
+variable "firecloud_sa_project_iam_roles" {
   type        = list(string)
   description = "A list of one or more roles to which the Firecloud SA will be added."
   default     = [
@@ -92,7 +99,7 @@ variable "firecloud_sa_name" {
   default     = ""
 }
 
-variable "leonardo_sa_iam_roles" {
+variable "leonardo_sa_project_iam_roles" {
   type        = list(string)
   description = "A list of one or more roles to which the Leonardo SA will be added."
   default     = [
@@ -105,7 +112,7 @@ variable "leonardo_sa_name" {
   default     = ""
 }
 
-variable "sam_sa_iam_roles" {
+variable "sam_sa_project_iam_roles" {
   type        = list(string)
   description = "A list of one or more roles to which the Sam SA will be added."
   default     = [

--- a/testrunner/variables.tf
+++ b/testrunner/variables.tf
@@ -67,3 +67,53 @@ locals {
   owner   = var.owner == "" ? terraform.workspace : var.owner
   service = "testrunner"
 }
+
+## The following entities were added on 24 Sep 2021 as part of a temporary
+## workaround to addres the IAM storage.admin role SA membership issue that
+## manifested as part of QA-1485 and QA-1526. See JIRA issue DDO-1542 for details.
+#
+# These variables will need to remain in this file until the following items are
+# complete:
+# - The changes for QA-1526 have been merged to master in terraform-ap-modules and
+#   terraform-ap-deployments.
+# - The changes required to manage these non-TestRunner entities have been moved
+#   to a common IAM module.
+
+variable "firecloud_sa_iam_roles" {
+  type        = list(string)
+  description = "A list of one or more roles to which the Firecloud SA will be added."
+  default     = [
+    "roles/storage.admin",
+  ]
+}
+
+variable "firecloud_sa_name" {
+  type        = string
+  default     = ""
+}
+
+variable "leonardo_sa_iam_roles" {
+  type        = list(string)
+  description = "A list of one or more roles to which the Leonardo SA will be added."
+  default     = [
+    "roles/storage.admin",
+  ]
+}
+
+variable "leonardo_sa_name" {
+  type        = string
+  default     = ""
+}
+
+variable "sam_sa_iam_roles" {
+  type        = list(string)
+  description = "A list of one or more roles to which the Sam SA will be added."
+  default     = [
+    "roles/storage.admin",
+  ]
+}
+
+variable "sam_sa_name" {
+  type        = string
+  default     = ""
+}

--- a/testrunner/variables.tf
+++ b/testrunner/variables.tf
@@ -31,7 +31,7 @@ variable "owner" {
 variable "testrunner_sa_project_iam_roles" {
   type        = list(string)
   description = "A list of one or more roles to which the TestRunner SA will be added."
-  default     = [
+  default = [
     "roles/bigquery.user",
     "roles/container.viewer",
     "roles/storage.admin",
@@ -41,7 +41,7 @@ variable "testrunner_sa_project_iam_roles" {
 variable "testrunner_cf_deployer_sa_project_iam_roles" {
   type        = list(string)
   description = "A list of one or more roles to which the TestRunner Cloud Function Deployer SA will be added."
-  default     = [
+  default = [
     "roles/cloudfunctions.admin",
   ]
 }
@@ -49,7 +49,7 @@ variable "testrunner_cf_deployer_sa_project_iam_roles" {
 variable "testrunner_streamer_sa_project_iam_roles" {
   type        = list(string)
   description = "A list of one or more project roles to which the TestRunner Streamer SA will be added."
-  default     = [
+  default = [
     "roles/bigquery.user",
   ]
 }
@@ -57,15 +57,15 @@ variable "testrunner_streamer_sa_project_iam_roles" {
 variable "testrunner_streamer_sa_storage_bucket_iam_roles" {
   type        = list(string)
   description = "A list of one or more storage bucket roles to which the TestRunner Streamer SA will be added."
-  default     = [
+  default = [
     "roles/storage.admin",
   ]
 }
 
 variable "gsp_automatic_sa_testrunner_results_bucket_pubsub_topic_publish_iam_roles" {
   type        = list(string)
-  description = "A list of one or more roles which the GSP Automatic SA will use to publish results to the TestRunner Results Bucket Topic." 
-  default     = [
+  description = "A list of one or more roles which the GSP Automatic SA will use to publish results to the TestRunner Results Bucket Topic."
+  default = [
     "roles/pubsub.publisher",
   ]
 }
@@ -89,38 +89,38 @@ locals {
 variable "firecloud_sa_project_iam_roles" {
   type        = list(string)
   description = "A list of one or more roles to which the Firecloud SA will be added."
-  default     = [
+  default = [
     "roles/storage.admin",
   ]
 }
 
 variable "firecloud_sa_name" {
-  type        = string
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "leonardo_sa_project_iam_roles" {
   type        = list(string)
   description = "A list of one or more roles to which the Leonardo SA will be added."
-  default     = [
+  default = [
     "roles/storage.admin",
   ]
 }
 
 variable "leonardo_sa_name" {
-  type        = string
-  default     = ""
+  type    = string
+  default = ""
 }
 
 variable "sam_sa_project_iam_roles" {
   type        = list(string)
   description = "A list of one or more roles to which the Sam SA will be added."
-  default     = [
+  default = [
     "roles/storage.admin",
   ]
 }
 
 variable "sam_sa_name" {
-  type        = string
-  default     = ""
+  type    = string
+  default = ""
 }

--- a/testrunner/variables.tf
+++ b/testrunner/variables.tf
@@ -4,25 +4,65 @@ variable "dependencies" {
   default     = []
   description = "Work-around for Terraform 0.12's lack of support for 'depends_on' in custom modules."
 }
+
 variable "enable" {
   type        = bool
   description = "Enable flag for this module. If set to false, no resources will be created."
   default     = true
 }
+
 variable "google_project" {
   type        = string
   description = "The google project in which to create resources"
 }
+
 variable "bucket_location" {
   type        = string
   description = "Google region in which to create buckets"
   default     = "us-central1"
 }
+
 variable "owner" {
   type        = string
   description = "Environment or developer. Defaults to TF workspace name if left blank."
   default     = ""
 }
+
+variable "testrunner_sa_iam_roles" {
+  type        = list(string)
+  description = "A list of one or more roles to which the TestRunner SA will be added."
+  default     = [
+    "roles/bigquery.user",
+    "roles/container.viewer",
+    "roles/storage.admin",
+  ]
+}
+
+variable "testrunner_cf_deployer_sa_iam_roles" {
+  type        = list(string)
+  description = "A list of one or more roles to which the TestRunner Cloud Function Deployer SA will be added."
+  default     = [
+    "roles/cloudfunctions.admin",
+  ]
+}
+
+variable "testrunner_cf_deployer_sa_runas_default_appspot_sa_iam_roles" {
+  type        = list(string)
+  description = "A list of one or more roles which the TestRunner CF Deployer SA will be able to run as the Default AppSpot SA."
+  default     = [
+    "roles/iam.serviceAccountUser",
+  ]
+}
+
+variable "testrunner_streamer_sa_iam_roles" {
+  type        = list(string)
+  description = "A list of one or more roles to which the TestRunner Streamer SA will be added."
+  default     = [
+    "roles/bigquery.user",
+    "roles/iam.serviceAccountUser",
+  ]
+}
+
 locals {
   owner   = var.owner == "" ? terraform.workspace : var.owner
   service = "testrunner"


### PR DESCRIPTION
I. Notes

1. This PR should be merged to `QA-1526` before `QA-1526` is merged to master.
2. This PR is a refactor to make it easier to implement a temporary fix for the storage.admin membership issue that manifested from the combination of `QA-1485` and `QA-1526`. As a side effect, if the pattern works as designed, it can be reused elsewhere.
3. Initial changes should result in the following:
    - An effective noop for most of the Google entities affected by this PR (but see next item).
    - Name changes for multiple TF entities on the TF side. 
    - The `google_project_iam_binding` `storage_admin` TF entity will be destroyed, so an additional change will be required to provide a temporary fix for this issue.
4. Successful Atlantis plan runs:
    - https://github.com/broadinstitute/terraform-ap-deployments/pull/424#issuecomment-926834570

II. Related PRs
    - https://github.com/broadinstitute/terraform-ap-deployments/pull/424

<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
