### PR TITLE
[AS-1015] Add flags to WSM database

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -71,7 +71,7 @@ module "sam" {
   firestore_folder_id          = var.sam_firestore_folder_id
 }
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.10"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=jr-wsm-db-flags"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -71,7 +71,7 @@ module "sam" {
   firestore_folder_id          = var.sam_firestore_folder_id
 }
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=jr-wsm-db-flags"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.7.11"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -17,7 +17,6 @@ module "cloudsql-pg13" {
   }
   cloudsql_tier = local.cloudsql_pg13_settings.tier
 
-  cloudsql_replication_type = null
   cloudsql_retained_backups = 28
 
   cloudsql_insights_config = {

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -1,6 +1,6 @@
 # Postgres 13 CloudSQL instance
 module "cloudsql-pg13" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.2.6"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-2.0.0"
 
   enable = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable
 

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -25,6 +25,16 @@ module "cloudsql-pg13" {
     record_application_tags = true,
     record_client_address   = true
   }
+  
+  cloudsql_database_flags = {
+    "log_checkpoints" = "on",
+    "log_connections" = "on",
+    "log_disconnections" = "on",
+    "log_lock_waits" = "on",
+    "log_min_error_statement" = "info",
+    "log_temp_files" = "0",
+    "log_min_duration_statement" = "-1"
+  }
 
   cloudsql_maintenance_window_enable = true
 

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -31,7 +31,7 @@ module "cloudsql-pg13" {
     "log_connections" = "on",
     "log_disconnections" = "on",
     "log_lock_waits" = "on",
-    "log_min_error_statement" = "info",
+    "log_min_error_statement" = "error",
     "log_temp_files" = "0",
     "log_min_duration_statement" = "-1"
   }


### PR DESCRIPTION
For fedramp findings. These only need be applied to the production database, and can be done one-off in the console, however I'm wondering if we want to codify them in our TF and have them applied to all envs.

<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
