### PR TITLE
DDO-1719 Adding IP/DNS for Thanos Sidecar deployed alongside prometheus

### DIFF
--- a/prometheus/dns.tf
+++ b/prometheus/dns.tf
@@ -6,7 +6,8 @@ data "google_dns_managed_zone" "dns_zone" {
   name     = var.dns_zone_name
 }
 locals {
-  fqdn = "${local.subdomain}.${data.google_dns_managed_zone.dns_zone[0].dns_name}"
+  fqdn        = "${local.subdomain}.${data.google_dns_managed_zone.dns_zone[0].dns_name}"
+  thanos_fqdn = "thanos-sidecar.${data.google_dns_managed_zone.dns_zone[0].dns_name}"
 }
 
 
@@ -20,4 +21,16 @@ resource "google_dns_record_set" "ingress" {
   type         = "A"
   ttl          = "300"
   rrdatas      = [google_compute_global_address.ingress_ip[0].address]
+}
+
+resource "google_dns_record_set" "thanos_a_record" {
+  count = var.enable_thanos ? 1 : 0
+
+  project      = local.project
+  provider     = google.dns
+  managed_zone = data.google_dns_managed_zone.dns_zone[0].name
+  name         = local.thanos_fqdn
+  type         = "A"
+  ttl          = "300"
+  rrdatas      = [google_compute_address.thanos_sidecar_ip[0].address]
 }

--- a/prometheus/ip.tf
+++ b/prometheus/ip.tf
@@ -6,3 +6,12 @@ resource "google_compute_global_address" "ingress_ip" {
 
   name = "terra-${local.owner}-${local.service}-ip"
 }
+
+resource "google_compute_address" "thanos_sidecar_ip" {
+  count = var.enable_thanos ? 1 : 0
+
+  provider = google.target
+  project  = var.google_project
+
+  name = "terra-${local.owner}-thanos-ip"
+}

--- a/prometheus/outputs.tf
+++ b/prometheus/outputs.tf
@@ -9,3 +9,13 @@ output "fqdn" {
   description = "Prometheus FQDN"
   value       = var.enable ? local.fqdn : null
 }
+
+output "thanos_ip" {
+  description = "ip address to access thanos sidecar"
+  value       = var.enable_thanos ? google_compute_address.thanos_sidecar_ip[0].address : null
+}
+
+output "thanos_fqdn" {
+  description = "FQDN to access thanos sidecar"
+  value       = var.enable_thanos ? local.fqdn : null
+}

--- a/prometheus/variables.tf
+++ b/prometheus/variables.tf
@@ -29,6 +29,12 @@ variable "enable" {
   default     = true
 }
 
+variable "enable_thanos" {
+  type        = bool
+  description = "whether to create networking resources for exposing thanos sidecar. This is used to aggregate across multiple prometheuses"
+  default     = false
+}
+
 # DNS vars
 variable "dns_zone_name" {
   type        = string


### PR DESCRIPTION
Adding a toggle `enable_thanos` that can be used to control whether a dns record and ip for the thanos sidecar on each prometheus deployment are created.

https://github.com/broadinstitute/terraform-ap-deployments/pull/464