### PR TITLE
[DDO-1862] Roll out cloudsql module bump past the breaking change

### DIFF
--- a/crl-janitor/cloudsql.tf
+++ b/crl-janitor/cloudsql.tf
@@ -1,5 +1,5 @@
 module "cloudsql" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.2.1"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-2.0.0"
 
   enable = var.enable
 
@@ -14,7 +14,15 @@ module "cloudsql" {
   }
   cloudsql_tier = var.db_tier
 
-  cloudsql_replication_type = null
+  cloudsql_database_flags = {
+    "log_checkpoints" = "on",
+    "log_connections" = "on",
+    "log_disconnections" = "on",
+    "log_lock_waits" = "on",
+    "log_min_error_statement" = "error",
+    "log_temp_files" = "0",
+    "log_min_duration_statement" = "-1"
+  }
 
   app_dbs = {
     "${local.service}" = {

--- a/identity-concentrator/cloudsql.tf
+++ b/identity-concentrator/cloudsql.tf
@@ -1,5 +1,5 @@
 module "cloudsql" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.1.0"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-2.0.0"
 
   enable = var.enable
 
@@ -14,7 +14,15 @@ module "cloudsql" {
   }
   cloudsql_tier = var.db_tier
 
-  cloudsql_replication_type = null
+  cloudsql_database_flags = {
+    "log_checkpoints" = "on",
+    "log_connections" = "on",
+    "log_disconnections" = "on",
+    "log_lock_waits" = "on",
+    "log_min_error_statement" = "error",
+    "log_temp_files" = "0",
+    "log_min_duration_statement" = "-1"
+  }
 
   app_dbs = {
     "${local.service}" = {

--- a/poc-service/cloudsql.tf
+++ b/poc-service/cloudsql.tf
@@ -1,5 +1,5 @@
 module "cloudsql" {
-  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-1.1.0"
+  source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-2.0.0"
 
   enable = var.enable
 
@@ -14,7 +14,15 @@ module "cloudsql" {
   }
   cloudsql_tier = var.db_tier
 
-  cloudsql_replication_type = null
+  cloudsql_database_flags = {
+    "log_checkpoints" = "on",
+    "log_connections" = "on",
+    "log_disconnections" = "on",
+    "log_lock_waits" = "on",
+    "log_min_error_statement" = "error",
+    "log_temp_files" = "0",
+    "log_min_duration_statement" = "-1"
+  }
 
   app_dbs = {
     "${local.service}" = {

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -12,7 +12,7 @@
  */
 
 module "poc_service" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//poc-service?ref=poc-service-0.1.2"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//poc-service?ref=DDO-1862-bump-cloudsql-module-versions"
 
   enable = local.terra_apps["poc"]
 
@@ -32,7 +32,7 @@ module "poc_service" {
 }
 
 module "identity_concentrator" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//identity-concentrator?ref=identity-concentrator-0.1.2"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//identity-concentrator?ref=DDO-1862-bump-cloudsql-module-versions"
   enable = local.terra_apps["identity_concentrator"]
 
   google_project = var.google_project
@@ -98,7 +98,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.2.9"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=DDO-1862-bump-cloudsql-module-versions"
 
   enable = local.terra_apps["crl_janitor"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -12,7 +12,7 @@
  */
 
 module "poc_service" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//poc-service?ref=DDO-1862-bump-cloudsql-module-versions"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//poc-service?ref=poc-service-0.1.3"
 
   enable = local.terra_apps["poc"]
 
@@ -32,7 +32,7 @@ module "poc_service" {
 }
 
 module "identity_concentrator" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//identity-concentrator?ref=DDO-1862-bump-cloudsql-module-versions"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//identity-concentrator?ref=identity-concentrator-0.1.3"
   enable = local.terra_apps["identity_concentrator"]
 
   google_project = var.google_project
@@ -98,7 +98,7 @@ module "workspace_manager" {
 }
 
 module "crl_janitor" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=DDO-1862-bump-cloudsql-module-versions"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//crl-janitor?ref=crl-janitor-0.2.10"
 
   enable = local.terra_apps["crl_janitor"]
 


### PR DESCRIPTION
<!--
The workflow from this repo's README must be followed when making changes to modules deployed with Atlantis from the terraform-ap-deployments repo!
-->
Just replicates what I helped Jackie and I did in https://github.com/broadinstitute/terraform-ap-modules/pull/208/files and similar PRs. This branch worked for @yonghaoy 's PR https://github.com/broadinstitute/terraform-ap-deployments/pull/513#issuecomment-1010252718

The tags now referenced are the ones I will create upon merge