### PR TITLE
unnecessary role

### DIFF
--- a/externalcreds/sa.tf
+++ b/externalcreds/sa.tf
@@ -20,8 +20,7 @@ locals {
   app_sa_roles = [
     "roles/cloudprofiler.agent",            # Profiling
     "roles/cloudtrace.agent",               # Tracing for monitoring
-    "roles/monitoring.editor",              # Exporting metrics
-    "roles/iam.serviceAccountTokenCreator", # For signing JWTs
+    "roles/monitoring.editor"               # Exporting metrics
   ]
 }
 


### PR DESCRIPTION
the original design called for `roles/iam.serviceAccountTokenCreator` but we didn't need it