### PR TITLE
[PF-1842] Add policy DB to WSM

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -71,8 +71,7 @@ module "sam" {
   firestore_folder_id          = var.sam_firestore_folder_id
 }
 module "workspace_manager" {
-  # TODO(zloery): bump me!
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=zl-pf1842"
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.9.0"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -71,7 +71,8 @@ module "sam" {
   firestore_folder_id          = var.sam_firestore_folder_id
 }
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.8.0"
+  # TODO(zloery): bump me!
+  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=zl-pf1842"
 
   enable = local.terra_apps["workspace_manager"]
 

--- a/terra-workspace-manager/README.md
+++ b/terra-workspace-manager/README.md
@@ -1,15 +1,15 @@
 # Terra Workspace Manager module
 
-This module creates the service account and CloudSQL databases necessary for  
-running the [Workspace Manager](http://github.com/databiosphere/terra-workspace-manager).  
-This currently requires two postgres databases: one for the workspace manager  
+This module creates the service account and CloudSQL databases necessary for
+running the [Workspace Manager](http://github.com/databiosphere/terra-workspace-manager).
+This currently requires two postgres databases: one for the workspace manager
 itself, and one for the Stairway library used for managing sagas.
 
-For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)  
+For more information, check out the [MC-Terra deployment doc](https://docs.dsp-devops.broadinstitute.org/mc-terra/mcterra-deployment)
 and our [Terraform best practices](https://docs.dsp-devops.broadinstitute.org/best-practices-guides/terraform).
 
 This documentation is generated with [terraform-docs](https://github.com/segmentio/terraform-docs)
-`terraform-docs markdown --no-sort . > README.md`
+`terraform-docs markdown --sort=false . > README.md`
 
 ## Requirements
 
@@ -19,49 +19,59 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| google.dns | n/a |
-| google.target | n/a |
-| google | n/a |
+| <a name="provider_google.dns"></a> [google.dns](#provider\_google.dns) | n/a |
+| <a name="provider_google.target"></a> [google.target](#provider\_google.target) | n/a |
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_enable-services"></a> [enable-services](#module\_enable-services) | github.com/broadinstitute/terraform-shared.git//terraform-modules/api-services | services-0.3.0-tf-0.12 |
+| <a name="module_cloudsql-pg13"></a> [cloudsql-pg13](#module\_cloudsql-pg13) | github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres | cloudsql-postgres-2.0.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_billing_account_iam_member.app](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/billing_account_iam_member) | resource |
+| [google_compute_global_address.ingress_ip](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_dns_record_set.ingress](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| [google_folder_iam_member.app_folder_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/folder_iam_member) | resource |
+| [google_project_iam_custom_role.app_sa_custom_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.app](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.app_custom_role_membership](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.sqlproxy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.app](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.sqlproxy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_dns_managed_zone.dns_zone](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_managed_zone) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| dependencies | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
-| enable | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
-| google\_project | The google project in which to create resources | `string` | n/a | yes |
-| cluster | Terra GKE cluster suffix, whatever is after terra- | `string` | n/a | yes |
-| cluster\_short | Optional short cluster name | `string` | `""` | no |
-| owner | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
-| env\_type | Environment type. Valid values are 'preview', 'preview\_shared', and 'default' | `string` | `"default"` | no |
-| workspace\_project\_folder\_id | What google folder within which to create a folder for creating workspace google projects. If empty, do not create a folder. | `string` | `""` | no |
-| workspace\_project\_folder\_ids | List of folder ids WSM will need to be able to access. Folders are created outside of WSM. | `list(string)` | `[]` | no |
-| billing\_account\_ids | List of Google billing account ids to allow WSM to use for billing workspace google projects. | `list(string)` | `[]` | no |
-| dns\_zone\_name | DNS zone name | `string` | `"dsp-envs"` | no |
-| use\_subdomain | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
-| subdomain\_name | Domain namespacing between zone and hostname | `string` | `""` | no |
-| hostname | Service hostname | `string` | `""` | no |
-| db\_version | The version for the CloudSQL instance | `string` | `"POSTGRES_12"` | no |
-| db\_keepers | Whether to use keepers to re-generate instance name. | `bool` | `true` | no |
-| db\_tier | The default tier (DB instance size) for the CloudSQL instance | `string` | `"db-g1-small"` | no |
-| db\_name | Postgres db name | `string` | `""` | no |
-| db\_user | Postgres username | `string` | `""` | no |
-| stairway\_db\_name | Stairway db name | `string` | `""` | no |
-| stairway\_db\_user | Stairway db username | `string` | `""` | no |
+| <a name="input_dependencies"></a> [dependencies](#input\_dependencies) | Work-around for Terraform 0.12's lack of support for 'depends\_on' in custom modules. | `any` | `[]` | no |
+| <a name="input_enable"></a> [enable](#input\_enable) | Enable flag for this module. If set to false, no resources will be created. | `bool` | `true` | no |
+| <a name="input_google_project"></a> [google\_project](#input\_google\_project) | The google project in which to create resources | `string` | n/a | yes |
+| <a name="input_cluster"></a> [cluster](#input\_cluster) | Terra GKE cluster suffix, whatever is after terra- | `string` | n/a | yes |
+| <a name="input_cluster_short"></a> [cluster\_short](#input\_cluster\_short) | Optional short cluster name | `string` | `""` | no |
+| <a name="input_owner"></a> [owner](#input\_owner) | Environment or developer. Defaults to TF workspace name if left blank. | `string` | `""` | no |
+| <a name="input_env_type"></a> [env\_type](#input\_env\_type) | Environment type. Valid values are 'preview', 'preview\_shared', and 'default' | `string` | `"default"` | no |
+| <a name="input_workspace_project_folder_ids"></a> [workspace\_project\_folder\_ids](#input\_workspace\_project\_folder\_ids) | List of folder ids WSM will need to be able to access. Folders are created outside of WSM. | `list(string)` | `[]` | no |
+| <a name="input_billing_account_ids"></a> [billing\_account\_ids](#input\_billing\_account\_ids) | List of Google billing account ids to allow WSM to use for billing workspace google projects. | `list(string)` | `[]` | no |
+| <a name="input_dns_zone_name"></a> [dns\_zone\_name](#input\_dns\_zone\_name) | DNS zone name | `string` | `"dsp-envs"` | no |
+| <a name="input_use_subdomain"></a> [use\_subdomain](#input\_use\_subdomain) | Whether to use a subdomain between the zone and hostname | `bool` | `true` | no |
+| <a name="input_subdomain_name"></a> [subdomain\_name](#input\_subdomain\_name) | Domain namespacing between zone and hostname | `string` | `""` | no |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | Service hostname | `string` | `""` | no |
+| <a name="input_cloudsql_pg13_settings"></a> [cloudsql\_pg13\_settings](#input\_cloudsql\_pg13\_settings) | Settings for Postgres 13 CloudSQL instance | `map` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| sqlproxy\_sa\_id | Workspace Manager Cloud SQL Proxy Google service account ID |
-| app\_sa\_id | Workspace Manager App Google service account ID |
-| workspace\_container\_folder\_id | The folder id of the folder that workspace projects should be created within. |
-| ingress\_ip | Workspace Manager ingress IP |
-| ingress\_ip\_name | Sam ingress IP name |
-| fqdn | Workspace Manager fully qualified domain name |
-| cloudsql\_public\_ip | Workspace Manager CloudSQL instance IP |
-| cloudsql\_instance\_name | Workspace Manager CloudSQL instance name |
-| cloudsql\_root\_user\_password | Workspace Manager database root password |
-| cloudsql\_app\_db\_creds | Workspace Manager database user credentials |
-| cloudsql\_app\_stairway\_db\_creds | Stairway database user credentials |
-
+| <a name="output_sqlproxy_sa_id"></a> [sqlproxy\_sa\_id](#output\_sqlproxy\_sa\_id) | Workspace Manager Cloud SQL Proxy Google service account ID |
+| <a name="output_app_sa_id"></a> [app\_sa\_id](#output\_app\_sa\_id) | Workspace Manager App Google service account ID |
+| <a name="output_ingress_ip"></a> [ingress\_ip](#output\_ingress\_ip) | Workspace Manager ingress IP |
+| <a name="output_ingress_ip_name"></a> [ingress\_ip\_name](#output\_ingress\_ip\_name) | Sam ingress IP name |
+| <a name="output_fqdn"></a> [fqdn](#output\_fqdn) | Workspace Manager fully qualified domain name |
+| <a name="output_cloudsql_pg13_outputs"></a> [cloudsql\_pg13\_outputs](#output\_cloudsql\_pg13\_outputs) | Workspace Manager CloudSQL outputs (pg13 instance) |

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -24,14 +24,14 @@ module "cloudsql-pg13" {
     record_application_tags = true,
     record_client_address   = true
   }
-  
+
   cloudsql_database_flags = {
-    "log_checkpoints" = "on",
-    "log_connections" = "on",
-    "log_disconnections" = "on",
-    "log_lock_waits" = "on",
-    "log_min_error_statement" = "error",
-    "log_temp_files" = "0",
+    "log_checkpoints"            = "on",
+    "log_connections"            = "on",
+    "log_disconnections"         = "on",
+    "log_lock_waits"             = "on",
+    "log_min_error_statement"    = "error",
+    "log_temp_files"             = "0",
     "log_min_duration_statement" = "-1"
   }
 

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -46,6 +46,10 @@ module "cloudsql-pg13" {
       db       = local.cloudsql_pg13_settings.stairway_db_name
       username = local.cloudsql_pg13_settings.stairway_db_user
     }
+    "${local.service}-policy" = {
+      db       = local.cloudsql_pg13_settings.policy_db_name
+      username = local.cloudsql_pg13_settings.policy_db_user
+    }
   }
 
   dependencies = [var.dependencies]

--- a/terra-workspace-manager/outputs.tf
+++ b/terra-workspace-manager/outputs.tf
@@ -42,6 +42,8 @@ output "cloudsql_pg13_outputs" {
     app_db_creds = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds[local.service]) : null
     # pg13 stairway db creds
     stairway_db_creds = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds["${local.service}-stairway"]) : null
+    # pg13 policy db creds
+    policy_db_creds = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds["${local.service}-policy"]) : null
   }
   sensitive = true
 }

--- a/terra-workspace-manager/sa.tf
+++ b/terra-workspace-manager/sa.tf
@@ -19,9 +19,9 @@ resource "google_project_iam_member" "sqlproxy" {
 locals {
   app_sa_roles = [
     "roles/cloudprofiler.agent", # Profiling
-    "roles/cloudtrace.agent", # Tracing for monitoring
-    "roles/monitoring.editor", # Exporting metrics
-    "roles/pubsub.editor", # Creating, publishing & subscribing pub/sub topics for multi-instance Stairway.
+    "roles/cloudtrace.agent",    # Tracing for monitoring
+    "roles/monitoring.editor",   # Exporting metrics
+    "roles/pubsub.editor",       # Creating, publishing & subscribing pub/sub topics for multi-instance Stairway.
   ]
 
   # For permissions from normally-admin roles that WSM needs for specific functionality
@@ -44,19 +44,19 @@ locals {
   ]
 
   folder_ids_and_roles = [
-  for pair in setproduct(local.app_folder_roles, var.workspace_project_folder_ids) : {
-    folder_role = pair[0]
-    folder_id = pair[1]
+    for pair in setproduct(local.app_folder_roles, var.workspace_project_folder_ids) : {
+      folder_role = pair[0]
+      folder_id   = pair[1]
   }]
 }
 
 resource "google_project_iam_custom_role" "app_sa_custom_role" {
   count = var.enable && contains(["default", "preview_shared"], var.env_type) ? 1 : 0
 
-  provider = google.target
-  project = var.google_project
-  role_id = "${local.service}${title(local.owner)}CustomRole"
-  title = "${local.service}-${local.owner} Custom Role"
+  provider    = google.target
+  project     = var.google_project
+  role_id     = "${local.service}${title(local.owner)}CustomRole"
+  title       = "${local.service}-${local.owner} Custom Role"
   description = "Custom role for ${local.service} ${local.owner}, managed by DevOps Atlantis `terra-env`"
   permissions = local.app_sa_custom_role_permissions
 }
@@ -88,10 +88,10 @@ resource "google_project_iam_member" "app_custom_role_membership" {
 
 # Grant WorkspaceManager Service App Service Account permission to modify resource in folder.
 resource "google_folder_iam_member" "app_folder_roles" {
-  count = var.enable ? length(local.folder_ids_and_roles): 0
+  count = var.enable ? length(local.folder_ids_and_roles) : 0
 
   provider = google.target
-  folder  = local.folder_ids_and_roles[count.index].folder_id
+  folder   = local.folder_ids_and_roles[count.index].folder_id
   role     = local.folder_ids_and_roles[count.index].folder_role
   member   = "serviceAccount:${google_service_account.app[0].email}"
 }

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -111,7 +111,7 @@ locals {
 }
 
 variable "cloudsql_pg13_settings" {
-  type        = map
+  type        = map(any)
   default     = {}
   description = "Settings for Postgres 13 CloudSQL instance"
 }

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -105,6 +105,8 @@ locals {
     db_user          = local.service,               # Name of app DB user
     stairway_db_name = "${local.service}-stairway", # Name of stairway DB
     stairway_db_user = "${local.service}-stairway", # Name of stairway DB user
+    policy_db_name   = "${local.service}-policy",   # Name of policy DB
+    policy_db_user   = "${local.service}-policy",   # Name of policy DB user
   }
 }
 


### PR DESCRIPTION
Update the WSM module to create an additional database for policy. This is intentionally a separate DB from the rest of WSM as we expect to split it off into a standalone service in the medium-term future.

(doc/formatting changes came from `terraform fmt` + `terraform-docs`, it looks like they haven't been run for this module recently)