### PR TITLE
[DDO-2761] Add Workload Identity for Leonardo

### DIFF
--- a/leonardo/variables.tf
+++ b/leonardo/variables.tf
@@ -26,6 +26,15 @@ variable "cluster_short" {
   description = "Optional short cluster name"
   default     = ""
 }
+variable "namespace" {
+  type        = string
+  description = "Optional Kubernetes namespace (defaults to terra-{cluster})"
+  default     = ""
+}
+locals {
+  namespace = var.namespace == "" ? "terra-${var.cluster}" : var.namespace
+}
+
 variable "owner" {
   type        = string
   description = "Environment or developer. Defaults to TF workspace name if left blank."
@@ -66,7 +75,7 @@ locals {
 }
 
 #
-# Used for the environment's Terra Docker Versions file bucket
+# Service account config
 #
 
 variable "service_accounts" {
@@ -74,6 +83,20 @@ variable "service_accounts" {
   description = "Externally managed service accounts of Terra services."
   default     = { leonardo = "" }
 }
+variable "enable_workload_identity" {
+  type        = bool
+  description = "Enable configuring application service accounts for Workload Identity"
+  default     = false
+}
+variable "kubernetes_sa_name" {
+  type        = string
+  description = "When Workload Identity is enabled, this Kubernetes SA in {namespace} will be able to impersonate Leonardo's Google SA"
+  default     = "leonardo-sa"
+}
+
+#
+# Used for the environment's Terra Docker Versions file bucket
+#
 
 variable "terra_docker_versions_upload_bucket" {
   type        = string

--- a/leonardo/workload-identity.tf
+++ b/leonardo/workload-identity.tf
@@ -1,0 +1,13 @@
+data "google_service_account" "leonardo_service_account" {
+  count      = var.enable && var.enable_workload_identity ? 1 : 0
+  project    = var.google_project
+  account_id = var.service_accounts["leonardo"]
+}
+
+resource "google_service_account_iam_member" "leonardo_workload_identity" {
+  count              = var.enable && var.enable_workload_identity ? 1 : 0
+  provider           = google.target
+  service_account_id = data.google_service_account.leonardo_service_account[0].unique_id
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.google_project}.svc.id.goog[${local.namespace}/${var.kubernetes_sa_name}]"
+}

--- a/leonardo/workload-identity.tf
+++ b/leonardo/workload-identity.tf
@@ -7,7 +7,7 @@ data "google_service_account" "leonardo_service_account" {
 resource "google_service_account_iam_member" "leonardo_workload_identity" {
   count              = var.enable && var.enable_workload_identity ? 1 : 0
   provider           = google.target
-  service_account_id = data.google_service_account.leonardo_service_account[0].unique_id
+  service_account_id = data.google_service_account.leonardo_service_account[0].name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.google_project}.svc.id.goog[${local.namespace}/${var.kubernetes_sa_name}]"
 }

--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -238,19 +238,22 @@ module "rawls" {
 }
 
 module "leonardo" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//leonardo?ref=leonardo-0.0.2"
+  source = "../leonardo"
 
   enable = local.terra_apps["leonardo"]
 
-  google_project = var.google_project
-  cluster        = var.cluster
-  cluster_short  = var.cluster_short
+  google_project           = var.google_project
+  service_accounts         = var.service_accounts
+  enable_workload_identity = var.enable_workload_identity
+
+  cluster       = var.cluster
+  cluster_short = var.cluster_short
+  namespace     = local.namespace
 
   dns_zone_name  = var.dns_zone_name
   subdomain_name = var.subdomain_name
   use_subdomain  = var.use_subdomain
 
-  service_accounts                    = var.service_accounts
   terra_docker_versions_upload_bucket = var.leonardo_terra_docker_versions_upload_bucket
 
   providers = {

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -24,11 +24,18 @@ variable "classic_storage_google_project" {
 locals {
   classic_storage_google_project = var.classic_storage_google_project == "" ? var.google_project : var.classic_storage_google_project
 }
+
 variable "service_accounts" {
   type        = map(string)
   description = "Externally managed service accounts of Terra services."
   default     = { rawls = "", leonardo = "" }
 }
+variable "enable_workload_identity" {
+  type        = bool
+  description = "Enable configuring application service accounts for Workload Identity"
+  default     = false
+}
+
 variable "cluster" {
   type        = string
   description = "Terra GKE cluster suffix, whatever is after terra-"
@@ -38,6 +45,16 @@ variable "cluster_short" {
   description = "Optional short cluster name"
   default     = ""
 }
+variable "namespace" {
+  type        = string
+  description = "Optional Kubernetes namespace (defaults to terra-{cluster})"
+  default     = ""
+}
+locals {
+  namespace = var.namespace == "" ? "terra-${var.cluster}" : var.namespace
+}
+
+
 variable "owner" {
   type        = string
   description = "Environment or developer. Defaults to TF workspace name if left blank."


### PR DESCRIPTION
**Note for anyone that follows my footsteps here:**

Leonardo's module was already getting its service account ID passed to it. For other apps, you'll need to add a variable for the `service_accounts` like the one that Leonardo's module is using. Beware that you should make sure the default value isn't null by modifying https://github.com/broadinstitute/terraform-ap-modules/blob/master/terra-env/variables.tf#L30