### PR TITLE
[WOR-1792] Add support for Workspace Manager in BEEs

### DIFF
--- a/terra-env/main.tf
+++ b/terra-env/main.tf
@@ -71,7 +71,7 @@ module "sam" {
   firestore_folder_id          = var.sam_firestore_folder_id
 }
 module "workspace_manager" {
-  source = "github.com/broadinstitute/terraform-ap-modules.git//terra-workspace-manager?ref=terra-workspace-manager-0.10.0"
+  source = "../terra-workspace-manager"
 
   enable = local.terra_apps["workspace_manager"]
 
@@ -81,10 +81,12 @@ module "workspace_manager" {
 
   env_type = var.env_type
 
+  dns_enabled    = var.dns_enabled
   dns_zone_name  = var.dns_zone_name
   subdomain_name = var.subdomain_name
   use_subdomain  = var.use_subdomain
 
+  cloudsql_enabled       = var.cloudsql_enabled
   cloudsql_pg13_settings = var.wsm_cloudsql_pg13_settings
 
   billing_account_ids          = var.wsm_billing_account_ids

--- a/terra-env/variables.tf
+++ b/terra-env/variables.tf
@@ -118,6 +118,11 @@ locals {
 #
 # DNS Vars
 #
+variable "dns_enabled" {
+  type        = bool
+  description = "If true, provision DNS records and static IP for Ingress"
+  default     = true
+}
 variable "dns_zone_name" {
   type        = string
   description = "DNS zone name"
@@ -131,6 +136,15 @@ variable "subdomain_name" {
 variable "use_subdomain" {
   type        = bool
   description = "Whether to use a subdomain between the zone and hostname"
+  default     = true
+}
+
+#
+# CloudSQL DB Vars
+#
+variable "cloudsql_enabled" {
+  type        = bool
+  description = "If true, provision a CloudSQL instance"
   default     = true
 }
 

--- a/terra-workspace-manager/cloudsql.tf
+++ b/terra-workspace-manager/cloudsql.tf
@@ -2,7 +2,7 @@
 module "cloudsql-pg13" {
   source = "github.com/broadinstitute/terraform-shared.git//terraform-modules/cloudsql-postgres?ref=cloudsql-postgres-2.0.0"
 
-  enable = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable
+  enable = var.enable && var.cloudsql_enabled && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable
 
   providers = {
     google.target = google.target

--- a/terra-workspace-manager/dns.tf
+++ b/terra-workspace-manager/dns.tf
@@ -1,16 +1,16 @@
 data "google_dns_managed_zone" "dns_zone" {
-  count = var.enable && contains(["default", "preview"], var.env_type) ? 1 : 0
+  count = var.enable && var.dns_enabled && contains(["default", "preview"], var.env_type) ? 1 : 0
 
   provider = google.dns
   name     = var.dns_zone_name
 }
 
 locals {
-  fqdn = var.enable && contains(["default", "preview"], var.env_type) ? "${local.hostname}${local.subdomain_name}.${data.google_dns_managed_zone.dns_zone[0].dns_name}" : null
+  fqdn = var.enable && var.dns_enabled && contains(["default", "preview"], var.env_type) ? "${local.hostname}${local.subdomain_name}.${data.google_dns_managed_zone.dns_zone[0].dns_name}" : null
 }
 
 resource "google_dns_record_set" "ingress" {
-  count = var.enable && contains(["default", "preview"], var.env_type) ? 1 : 0
+  count = var.enable && var.dns_enabled && contains(["default", "preview"], var.env_type) ? 1 : 0
 
   provider     = google.dns
   managed_zone = data.google_dns_managed_zone.dns_zone[0].name

--- a/terra-workspace-manager/dns.tf
+++ b/terra-workspace-manager/dns.tf
@@ -2,7 +2,7 @@ data "google_dns_managed_zone" "dns_zone" {
   count = var.enable && var.dns_enabled && contains(["default", "preview"], var.env_type) ? 1 : 0
 
   provider = google.dns
-  name     = var.enable && var.dns_enabled && contains(["default", "preview"], var.env_type) ? var.dns_zone_name : null
+  name     = var.dns_zone_name
 }
 
 locals {

--- a/terra-workspace-manager/dns.tf
+++ b/terra-workspace-manager/dns.tf
@@ -2,7 +2,7 @@ data "google_dns_managed_zone" "dns_zone" {
   count = var.enable && var.dns_enabled && contains(["default", "preview"], var.env_type) ? 1 : 0
 
   provider = google.dns
-  name     = var.dns_zone_name
+  name     = var.enable && var.dns_enabled && contains(["default", "preview"], var.env_type) ? var.dns_zone_name : null
 }
 
 locals {

--- a/terra-workspace-manager/ip.tf
+++ b/terra-workspace-manager/ip.tf
@@ -1,5 +1,5 @@
 resource "google_compute_global_address" "ingress_ip" {
-  count = var.enable && contains(["default", "preview"], var.env_type) ? 1 : 0
+  count = var.enable && var.dns_enabled && contains(["default", "preview"], var.env_type) ? 1 : 0
 
   provider = google.target
 

--- a/terra-workspace-manager/outputs.tf
+++ b/terra-workspace-manager/outputs.tf
@@ -14,15 +14,15 @@ output "app_sa_id" {
 # IP/DNS Outputs
 #
 output "ingress_ip" {
-  value       = var.enable && contains(["default", "preview"], var.env_type) ? google_compute_global_address.ingress_ip[0].address : null
+  value       = var.enable && var.dns_enabled && contains(["default", "preview"], var.env_type) ? google_compute_global_address.ingress_ip[0].address : null
   description = "Workspace Manager ingress IP"
 }
 output "ingress_ip_name" {
-  value       = var.enable && contains(["default", "preview"], var.env_type) ? google_compute_global_address.ingress_ip[0].name : null
+  value       = var.enable && var.dns_enabled && contains(["default", "preview"], var.env_type) ? google_compute_global_address.ingress_ip[0].name : null
   description = "Sam ingress IP name"
 }
 output "fqdn" {
-  value       = var.enable && contains(["default", "preview"], var.env_type) ? local.fqdn : null
+  value       = var.enable && var.dns_enabled && contains(["default", "preview"], var.env_type) ? local.fqdn : null
   description = "Workspace Manager fully qualified domain name"
 }
 
@@ -33,21 +33,21 @@ output "cloudsql_pg13_outputs" {
   description = "Workspace Manager CloudSQL outputs (pg13 instance)"
   value = {
     # pg13 CloudSQL instance IP
-    public_ip = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? module.cloudsql-pg13.public_ip : null,
+    public_ip = var.enable && var.cloudsql_enabled && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? module.cloudsql-pg13.public_ip : null,
     # pg13 CloudSQL instance name
-    instance_name = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? module.cloudsql-pg13.instance_name : null
+    instance_name = var.enable && var.cloudsql_enabled && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? module.cloudsql-pg13.instance_name : null
     # pg13 database root password
-    root_user_password = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? module.cloudsql-pg13.root_user_password : null
+    root_user_password = var.enable && var.cloudsql_enabled && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? module.cloudsql-pg13.root_user_password : null
     # pg13 app db creds
-    app_db_creds = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds[local.service]) : null
+    app_db_creds = var.enable && var.cloudsql_enabled && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds[local.service]) : null
     # pg13 stairway db creds
-    stairway_db_creds = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds["${local.service}-stairway"]) : null
+    stairway_db_creds = var.enable && var.cloudsql_enabled && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds["${local.service}-stairway"]) : null
     # pg13 policy db creds
-    policy_db_creds = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds["${local.service}-policy"]) : null
+    policy_db_creds = var.enable && var.cloudsql_enabled && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds["${local.service}-policy"]) : null
     # pg13 landingzone db creds
-    landingzone_db_creds = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds["${local.service}-landingzone"]) : null
+    landingzone_db_creds = var.enable && var.cloudsql_enabled && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds["${local.service}-landingzone"]) : null
     # pg13 landingzone stairway db creds
-    landingzone_stairway_db_creds = var.enable && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds["${local.service}-landingzone-stairway"]) : null
+    landingzone_stairway_db_creds = var.enable && var.cloudsql_enabled && contains(["default"], var.env_type) && local.cloudsql_pg13_settings.enable ? (length(module.cloudsql-pg13.app_db_creds) == 0 ? {} : module.cloudsql-pg13.app_db_creds["${local.service}-landingzone-stairway"]) : null
   }
   sensitive = true
 }

--- a/terra-workspace-manager/variables.tf
+++ b/terra-workspace-manager/variables.tf
@@ -65,6 +65,11 @@ variable "billing_account_ids" {
 #
 # DNS Vars
 #
+variable "dns_enabled" {
+  type        = bool
+  description = "If true, provision DNS records and static IP for Ingress"
+  default     = true
+}
 variable "dns_zone_name" {
   type        = string
   description = "DNS zone name"
@@ -112,6 +117,12 @@ locals {
     landingzone_stairway_db_name = "${local.service}-landingzone-stairway", #Name of Azure LandingZone Stairway DB
     landingzone_stairway_db_user = "${local.service}-landingzone-stairway"  #Name of Azure LandingZone Stairway DB user
   }
+}
+
+variable "cloudsql_enabled" {
+  type        = bool
+  description = "If true, provision a CloudSQL instance"
+  default     = true
 }
 
 variable "cloudsql_pg13_settings" {


### PR DESCRIPTION
Update `terra-env` and `terra-workspace-manager` modules to accept `dns_enabled` and `cloudsql_enabled` flags.

These will be used by `terraform-ap-deployments` to set up a service account for WSM in `broad-dsde-qa`. We want to set up the SA/IAM, but not CloudSQL or DNS.

See (deployments PR).